### PR TITLE
Attest immediately if block from proposer - fix #966

### DIFF
--- a/beacon_chain/beacon_node_common.nim
+++ b/beacon_chain/beacon_node_common.nim
@@ -44,7 +44,7 @@ const MaxEmptySlotCount* = uint64(10*60) div SECONDS_PER_SLOT
 declareGauge beacon_head_root,
   "Root of the head block of the beacon chain"
 
-proc updateHead*(node: BeaconNode): BlockRef =
+proc updateHead*(node: BeaconNode, logNoUpdate = true): BlockRef =
   # Check pending attestations - maybe we found some blocks for them
   node.attestationPool.resolve()
 
@@ -53,7 +53,7 @@ proc updateHead*(node: BeaconNode): BlockRef =
 
   # Store the new head in the block pool - this may cause epochs to be
   # justified and finalized
-  node.blockPool.updateHead(newHead)
+  node.blockPool.updateHead(newHead, logNoUpdate)
   beacon_head_root.set newHead.root.toGaugeValue
 
   newHead

--- a/beacon_chain/beacon_node_types.nim
+++ b/beacon_chain/beacon_node_types.nim
@@ -170,6 +170,10 @@ type
 
     slot*: Slot # TODO could calculate this by walking to root, but..
 
+    # Cache for ProtoArray fork-choice
+    justified_checkpoint*: Checkpoint
+    finalized_checkpoint*: Checkpoint
+
   BlockData* = object
     ## Body and graph in one
 
@@ -195,6 +199,7 @@ type
       ## has advanced without blocks
 
   Head* = object
+    # TODO: delete - all BlockRef tracks the justified checkpoint
     blck*: BlockRef
     justified*: BlockSlot
 

--- a/beacon_chain/block_pool.nim
+++ b/beacon_chain/block_pool.nim
@@ -872,7 +872,7 @@ proc delState(pool: BlockPool, bs: BlockSlot) =
   if (let root = pool.db.getStateRoot(bs.blck.root, bs.slot); root.isSome()):
     pool.db.delState(root.get())
 
-proc updateHead*(pool: BlockPool, newHead: BlockRef, logNoUpdate: bool) =
+proc updateHead*(pool: BlockPool, newHead: BlockRef, logNoUpdate = false) =
   ## Update what we consider to be the current head, as given by the fork
   ## choice.
   ## The choice of head affects the choice of finalization point - the order

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -645,6 +645,12 @@ func shortLog*(v: Attestation): auto =
     signature: shortLog(v.signature)
   )
 
+func shortLog*(cp: Checkpoint): auto =
+  (
+    epoch: cp.epoch,
+    root: shortLog(cp.root)
+  )
+
 chronicles.formatIt Slot: it.shortLog
 chronicles.formatIt Epoch: it.shortLog
 chronicles.formatIt BeaconBlock: it.shortLog

--- a/beacon_chain/spec/state_transition_helpers.nim
+++ b/beacon_chain/spec/state_transition_helpers.nim
@@ -13,14 +13,6 @@ import
   # Internals
   ./datatypes, ./digest, ./beaconstate
 
-# Logging utilities
-# --------------------------------------------------------
-
-# TODO: gather all logging utilities
-#       from crypto, digest, etc in a single file
-func shortLog*(x: Checkpoint): string =
-  "(epoch: " & $x.epoch & ", root: \"" & shortLog(x.root) & "\")"
-
 # Helpers used in epoch transition and trace-level block transition
 # --------------------------------------------------------
 

--- a/beacon_chain/validator_duties.nim
+++ b/beacon_chain/validator_duties.nim
@@ -432,6 +432,9 @@ proc handleValidatorDuties*(
 
   const attCutoff = chronos.seconds(SECONDS_PER_SLOT.int64 div 3)
   let cutoffFromNow = node.beaconClock.fromNow(slot.toBeaconTime(attCutoff))
+  # TODO: timeout investigation, to be removed
+  info "Looking to attest to a block",
+    timeout = cutoffFromNow
 
   if cutoffFromNow.inFuture:
     let foundBlockInTime = await withTimeout(


### PR DESCRIPTION
This PR does 2 things:

1. Fix #966, when we receive a block from the expected proposer, we attest immediately

2. BlockRef now stores the justified and finalized checkpoints which will avoid rewinding state in the fork choice PR at https://github.com/status-im/nim-beacon-chain/pull/965/files#diff-a007e749710608c06418bb9fcdf140dbR276-R302, https://github.com/status-im/nim-beacon-chain/blob/7dba780a1d2503c04bcaf360b1c1d8410807dd18/beacon_chain/attestation_pool.nim#L276-L302