### PR TITLE
Introduce `lent` to the project

### DIFF
--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -66,13 +66,13 @@ func get_total_active_balance*(state: BeaconState, cache: var StateCache): Gwei 
     state, cache.get_shuffled_active_validator_indices(state, epoch))
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/beacon-chain.md#helper-functions-1
-template get_matching_source_attestations(state: BeaconState,
-                                          epoch: Epoch): seq[PendingAttestation] =
+func get_matching_source_attestations(state: BeaconState,
+                                      epoch: Epoch): lent seq[PendingAttestation] =
   doAssert epoch in [get_current_epoch(state), get_previous_epoch(state)]
   if epoch == get_current_epoch(state):
-    state.current_epoch_attestations.asSeq
+    return state.current_epoch_attestations.asSeq
   else:
-    state.previous_epoch_attestations.asSeq
+    return state.previous_epoch_attestations.asSeq
 
 func get_matching_target_attestations(state: BeaconState, epoch: Epoch):
     seq[PendingAttestation] =


### PR DESCRIPTION
The generated code looks correct:

```C++
N_LIB_PRIVATE N_NIMCALL(tySequence__ovIt9aYo0Udhfm6IOo9c0QXQ**, get_matching_source_attestations__o9b1zJMASMvpgvjVgXwI6hg)(tyObject_BeaconState__9bhMe9a4J5kbuMT5CPSjMaaQ* state_0, NU64 epoch_0) {	tySequence__ovIt9aYo0Udhfm6IOo9c0QXQ** result;{	result = (tySequence__ovIt9aYo0Udhfm6IOo9c0QXQ**)0;
	{		tyArray__NzKR9bw29cLPrd712Xt6Liiw T3_;		NIM_BOOL T4_;
		T3_[0] = get_current_epoch__ZplWFey61DxgHKVOEXwJEw(state_0);
		T3_[1] = get_previous_epoch__Dz4vqJxFXzBcgrhrgVCEUQ(state_0);
		T4_ = (NIM_BOOL)0;		T4_ = contains__GmANvwKJ6K2sDGPL2RMJdwsystem(T3_, 2, epoch_0);		if (!!(T4_)) goto LA5_;

		failedAssertImpl__W9cjVocn1tjhW7p7xohJj6A(((NimStringDesc*) &TM__mCcYCUjcPEuw54QkEhLW3w_49));
	}
	LA5_: ;

	{		NU64 T9_;
		T9_ = (NU64)0;		T9_ = get_current_epoch__ZplWFey61DxgHKVOEXwJEw(state_0);		if (!(epoch_0 == T9_)) goto LA10_;

		result = (&(*state_0).current_epoch_attestations.data);		goto BeforeRet_;
	}
	goto LA7_;
	LA10_: ;
	{
		result = (&(*state_0).previous_epoch_attestations.data);		goto BeforeRet_;
	}
	LA7_: ;
	}BeforeRet_: ;
	return result;
}
```

Nim doesn't seem to be able to handle the `result = if: ... else: ...` construct though, so I had to go for these explicit returns.