### PR TITLE
use Zinken-compatible message IDs

### DIFF
--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -1321,7 +1321,7 @@ func gossipId(data: openArray[byte]): string =
   var msgDigest = sha256.digest(data).data
 
   # We only use snappy-compressed messages.
-  msgDigest[0] = msgDigest[0] and 127
+  msgDigest[0] = msgDigest[0] or 128
 
   string.fromBytes(msgDigest.toOpenArray(0, 19))
 

--- a/beacon_chain/eth2_processor.nim
+++ b/beacon_chain/eth2_processor.nim
@@ -301,7 +301,7 @@ proc attestationValidator*(
 
   # Potential under/overflows are fine; would just create odd metrics and logs
   let delay = wallTime - attestation.data.slot.toBeaconTime
-  trace "Attestation received", delay
+  debug "Attestation received", delay
   let v = self.attestationPool[].validateAttestation(
       attestation, wallTime, committeeIndex)
   if v.isErr():


### PR DESCRIPTION
Logtrace needs the "Attestation received" log message to pair with "Attestation sent", and thus either one needs to run in TRACE for that (overkill, usually, especially on the libp2p message side, but even in nbc) or that message needs to show up in DEBUG.