### PR TITLE
add v1.0.0-rc.0 support behind compile-time flag

### DIFF
--- a/beacon_chain.nimble
+++ b/beacon_chain.nimble
@@ -51,7 +51,7 @@ proc buildAndRunBinary(name: string, srcDir = "./", params = "", cmdParams = "",
 task moduleTests, "Run all module tests":
   buildAndRunBinary "beacon_node", "beacon_chain/",
               "-d:chronicles_log_level=TRACE " &
-              "-d:const_preset=minimal " &
+              "-d:const_preset=minimal -d:ETH2_SPEC=\"v0.12.3\" " &
               "-d:testutils_test_build"
 
 ### tasks
@@ -61,32 +61,37 @@ task test, "Run all tests":
   # price we pay for that.
 
   # Just the part of minimal config which explicitly differs from mainnet
-  buildAndRunBinary "test_fixture_const_sanity_check", "tests/official/", """-d:const_preset=minimal -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "test_fixture_const_sanity_check", "tests/official/", """-d:const_preset=minimal -d:ETH2_SPEC="v0.12.3" -d:chronicles_sinks="json[file]""""
+
+  buildAndRunBinary "test_fixture_const_sanity_check", "tests/official/", """-d:const_preset=mainnet -d:ETH2_SPEC="v1.0.0" -d:chronicles_sinks="json[file]""""
 
   # Generic SSZ test, doesn't use consensus objects minimal/mainnet presets
   buildAndRunBinary "test_fixture_ssz_generic_types", "tests/official/", """-d:chronicles_log_level=TRACE -d:chronicles_sinks="json[file]""""
 
-  # Consensus object SSZ tests; TODO switch back to mainnet when vectors exist
-  buildAndRunBinary "test_fixture_ssz_consensus_objects", "tests/official/", """-d:chronicles_log_level=TRACE -d:const_preset=minimal -d:chronicles_sinks="json[file]""""
+  # Consensus object SSZ tests
+  buildAndRunBinary "test_fixture_ssz_consensus_objects", "tests/official/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v1.0.0" -d:chronicles_sinks="json[file]""""
+
+  # Consensus object SSZ tests
+  buildAndRunBinary "test_fixture_ssz_consensus_objects", "tests/official/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v0.12.3" -d:chronicles_sinks="json[file]""""
 
   # EF tests
-  buildAndRunBinary "all_fixtures_require_ssz", "tests/official/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "all_fixtures_require_ssz", "tests/official/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v0.12.3" -d:chronicles_sinks="json[file]""""
 
   # Mainnet config
-  buildAndRunBinary "proto_array", "beacon_chain/fork_choice/", """-d:const_preset=mainnet -d:chronicles_sinks="json[file]""""
-  buildAndRunBinary "fork_choice", "beacon_chain/fork_choice/", """-d:const_preset=mainnet -d:chronicles_sinks="json[file]""""
-  buildAndRunBinary "all_tests", "tests/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "proto_array", "beacon_chain/fork_choice/", """-d:const_preset=mainnet -d:ETH2_SPEC="v0.12.3" -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "fork_choice", "beacon_chain/fork_choice/", """-d:const_preset=mainnet -d:ETH2_SPEC="v0.12.3" -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "all_tests", "tests/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v0.12.3" -d:chronicles_sinks="json[file]""""
 
   # Check Miracl/Milagro fallback on select tests
-  buildAndRunBinary "test_interop", "tests/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
-  buildAndRunBinary "test_process_attestation", "tests/spec_block_processing/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
-  buildAndRunBinary "test_process_deposits", "tests/spec_block_processing/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
-  buildAndRunBinary "all_fixtures_require_ssz", "tests/official/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
-  buildAndRunBinary "test_attestation_pool", "tests/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
-  buildAndRunBinary "test_block_pool", "tests/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "test_interop", "tests/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v0.12.3" -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "test_process_attestation", "tests/spec_block_processing/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v0.12.3" -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "test_process_deposits", "tests/spec_block_processing/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v0.12.3" -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "all_fixtures_require_ssz", "tests/official/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v0.12.3" -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "test_attestation_pool", "tests/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v0.12.3" -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "test_block_pool", "tests/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v0.12.3" -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
 
   # State and block sims; getting to 4th epoch triggers consensus checks
-  buildAndRunBinary "state_sim", "research/", "-d:const_preset=mainnet -d:chronicles_log_level=INFO", "--validators=3000 --slots=128"
-  # buildAndRunBinary "state_sim", "research/", "-d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl -d:chronicles_log_level=INFO", "--validators=3000 --slots=128"
-  buildAndRunBinary "block_sim", "research/", "-d:const_preset=mainnet", "--validators=3000 --slots=128"
-  # buildAndRunBinary "block_sim", "research/", "-d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl", "--validators=3000 --slots=128"
+  buildAndRunBinary "state_sim", "research/", "-d:const_preset=mainnet -d:ETH2_SPEC=\"v0.12.3\" -d:chronicles_log_level=INFO", "--validators=3000 --slots=128"
+  # buildAndRunBinary "state_sim", "research/", "-d:const_preset=mainnet -d:ETH2_SPEC=\"v0.12.3\" -d:BLS_FORCE_BACKEND=miracl -d:chronicles_log_level=INFO", "--validators=3000 --slots=128"
+  buildAndRunBinary "block_sim", "research/", "-d:const_preset=mainnet -d:ETH2_SPEC=\"v0.12.3\"", "--validators=3000 --slots=128"
+  # buildAndRunBinary "block_sim", "research/", "-d:const_preset=mainnet -d:ETH2_SPEC=\"v0.12.3\" -d:BLS_FORCE_BACKEND=miracl", "--validators=3000 --slots=128"

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -46,10 +46,13 @@ export
 # Eventually, we could also differentiate between user/tainted data and
 # internal state that's gone through sanity checks already.
 
-const
-  SPEC_VERSION* = "0.12.3" ## \
+when ETH2_SPEC == "v0.12.3":
+  const SPEC_VERSION* = "0.12.3"
+else:
+  const SPEC_VERSION* = "1.0.0-rc.0"
   ## Spec version we're aiming to be compatible with, right now
 
+const
   GENESIS_SLOT* = Slot(0)
   GENESIS_EPOCH* = (GENESIS_SLOT.uint64 div SLOTS_PER_EPOCH).Epoch ##\
   ## compute_epoch_at_slot(GENESIS_SLOT)
@@ -68,7 +71,8 @@ const
   # https://github.com/ethereum/eth2.0-specs/blob/v0.12.3/specs/phase0/p2p-interface.md#configuration
   ATTESTATION_PROPAGATION_SLOT_RANGE* = 32
 
-  SLOTS_PER_ETH1_VOTING_PERIOD* = EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH
+  SLOTS_PER_ETH1_VOTING_PERIOD* =
+    EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH
 
   DEPOSIT_CONTRACT_TREE_DEPTH* = 32
   BASE_REWARDS_PER_EPOCH* = 4

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -122,14 +122,25 @@ proc readPresetFile*(path: string): PresetFile
 
   result.missingValues = PresetValue.entireSet - presetValues
 
-const
-  mainnetRuntimePreset* = RuntimePreset(
+const ETH2_SPEC* {.strdefine.} = "v0.12.3"
+static: doAssert: ETH2_SPEC == "v0.12.3" or ETH2_SPEC == "v1.0.0"
+
+when ETH2_SPEC == "v0.12.3":
+  const mainnetRuntimePreset* = RuntimePreset(
     MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 16384,
     MIN_GENESIS_TIME: 1578009600,
     GENESIS_FORK_VERSION: Version [byte 0, 0, 0, 0],
     GENESIS_DELAY: 172800,
     ETH1_FOLLOW_DISTANCE: 1024)
+else:
+ const mainnetRuntimePreset* = RuntimePreset(
+    MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 16384,
+    MIN_GENESIS_TIME: 1578009600,
+    GENESIS_FORK_VERSION: Version [byte 0, 0, 0, 0],
+    GENESIS_DELAY: 604800,
+    ETH1_FOLLOW_DISTANCE: 1024)
 
+const
   minimalRuntimePreset* = RuntimePreset(
     MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 64,
     MIN_GENESIS_TIME: 1578009600,
@@ -139,12 +150,18 @@ const
 
 when const_preset == "mainnet":
   template defaultRuntimePreset*: auto = mainnetRuntimePreset
-  import ./presets/v0_12_3/mainnet
+  when ETH2_SPEC == "v0.12.3":
+    import ./presets/v0_12_3/mainnet
+  else:
+    import ./presets/v1_0_0-rc_0/mainnet
   export mainnet
 
 elif const_preset == "minimal":
   template defaultRuntimePreset*: auto = minimalRuntimePreset
-  import ./presets/v0_12_3/minimal
+  when ETH2_SPEC == "v0.12.3":
+    import ./presets/v0_12_3/minimal
+  else:
+    import ./presets/v1_0_0-rc_0/minimal
   export minimal
 
 else:

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -138,7 +138,7 @@ else:
     MIN_GENESIS_TIME: 1578009600,
     GENESIS_FORK_VERSION: Version [byte 0, 0, 0, 0],
     GENESIS_DELAY: 604800,
-    ETH1_FOLLOW_DISTANCE: 1024)
+    ETH1_FOLLOW_DISTANCE: 2048)
 
 const
   minimalRuntimePreset* = RuntimePreset(

--- a/beacon_chain/spec/presets/v1_0_0-rc_0/mainnet.nim
+++ b/beacon_chain/spec/presets/v1_0_0-rc_0/mainnet.nim
@@ -1,0 +1,167 @@
+# beacon_chain
+# Copyright (c) 2018-2020 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# This file contains constants that are part of the spec and thus subject to
+# serialization and spec updates.
+
+import
+  math
+
+{.experimental: "codeReordering".} # SLOTS_PER_EPOCH is use before being defined in spec
+
+const
+  # Misc
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.3/configs/mainnet/phase0.yaml#L6
+  CONFIG_NAME* = "mainnet"
+
+  MAX_COMMITTEES_PER_SLOT* {.intdefine.}: uint64 = 64
+
+  TARGET_COMMITTEE_SIZE*: uint64 = 128 ##\
+  ## Number of validators in the committee attesting to one shard
+  ## Per spec:
+  ## For the safety of crosslinks `TARGET_COMMITTEE_SIZE` exceeds
+  ## [the recommended minimum committee size of 111](https://vitalik.ca/files/Ithaca201807_Sharding.pdf);
+  ## with sufficient active validators (at least
+  ## `SLOTS_PER_EPOCH * TARGET_COMMITTEE_SIZE`), the shuffling algorithm ensures
+  ## committee sizes at least `TARGET_COMMITTEE_SIZE`. (Unbiasable randomness
+  ## with a Verifiable Delay Function (VDF) will improve committee robustness
+  ## and lower the safe minimum committee size.)
+
+  MAX_VALIDATORS_PER_COMMITTEE*: uint64 = 2048 ##\
+  ## votes
+
+  MIN_PER_EPOCH_CHURN_LIMIT*: uint64 = 4
+  CHURN_LIMIT_QUOTIENT*: uint64 = 2'u64 ^ 16
+  SHUFFLE_ROUND_COUNT*: uint64 = 90
+
+  HYSTERESIS_QUOTIENT*: uint64 = 4
+  HYSTERESIS_DOWNWARD_MULTIPLIER*: uint64 = 1
+  HYSTERESIS_UPWARD_MULTIPLIER*: uint64 = 5
+
+  # Gwei values
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.3/configs/mainnet/phase0.yaml#L61
+
+  MIN_DEPOSIT_AMOUNT*: uint64 = 2'u64^0 * 10'u64^9 ##\
+  ## Minimum amounth of ETH that can be deposited in one call - deposits can
+  ## be used either to top up an existing validator or commit to a new one
+
+  MAX_EFFECTIVE_BALANCE*: uint64 = 2'u64^5 * 10'u64^9 ##\
+  ## Maximum amounth of ETH that can be deposited in one call
+
+  EJECTION_BALANCE*: uint64 = 2'u64^4 * 10'u64^9 ##\
+  ## Once the balance of a validator drops below this, it will be ejected from
+  ## the validator pool
+
+  EFFECTIVE_BALANCE_INCREMENT*: uint64 = 2'u64^0 * 10'u64^9
+
+  # Initial values
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.3/configs/mainnet/phase0.yaml#L73
+  BLS_WITHDRAWAL_PREFIX*: byte = 0
+
+  # Time parameters
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.3/configs/mainnet/phase0.yaml#L80
+  SECONDS_PER_SLOT* {.intdefine.}: uint64 = 12'u64 # Compile with -d:SECONDS_PER_SLOT=1 for 12x faster slots
+  ## TODO consistent time unit across projects, similar to C++ chrono?
+
+  MIN_ATTESTATION_INCLUSION_DELAY*: uint64 = 1 ##\
+  ## (12 seconds)
+  ## Number of slots that attestations stay in the attestation
+  ## pool before being added to a block.
+  ## The attestation delay exists so that there is time for attestations to
+  ## propagate before the block is created.
+  ## When creating an attestation, the validator will look at the best
+  ## information known to at that time, and may not revise it during the same
+  ## slot (see `is_double_vote`) - the delay gives the validator a chance to
+  ## wait towards the end of the slot and still have time to publish the
+  ## attestation.
+
+  SLOTS_PER_EPOCH* {.intdefine.}: uint64 = 32 ##\
+  ## (~6.4 minutes)
+  ## slots that make up an epoch, at the end of which more heavy
+  ## processing is done
+  ## Compile with -d:SLOTS_PER_EPOCH=4 for shorter epochs
+
+  MIN_SEED_LOOKAHEAD*: uint64 = 1 ##\
+  ## epochs (~6.4 minutes)
+
+  MAX_SEED_LOOKAHEAD*: uint64 = 4 ##\
+  ## epochs (~25.6 minutes)
+
+  EPOCHS_PER_ETH1_VOTING_PERIOD*: uint64 = 64 ##\
+  ##  epochs (~6.8 hours)
+
+  SLOTS_PER_HISTORICAL_ROOT*: uint64 = 8192 ##\
+  ## slots (13 hours)
+
+  MIN_VALIDATOR_WITHDRAWABILITY_DELAY*: uint64 = 2'u64^8 ##\
+  ## epochs (~27 hours)
+
+  SHARD_COMMITTEE_PERIOD*: uint64 = 256 # epochs (~27 hours)
+
+  MIN_EPOCHS_TO_INACTIVITY_PENALTY*: uint64 = 2'u64^2 ##\
+  ## epochs (25.6 minutes)
+
+  # State vector lengths
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.3/configs/mainnet/phase0.yaml#L108
+
+  EPOCHS_PER_HISTORICAL_VECTOR*: uint64 = 65536 ##\
+  ## epochs (~0.8 years)
+
+  EPOCHS_PER_SLASHINGS_VECTOR*: uint64 = 8192 ##\
+  ## epochs (~36 days)
+
+  HISTORICAL_ROOTS_LIMIT*: uint64 = 16777216 ##\
+  ## epochs (~26,131 years)
+
+  VALIDATOR_REGISTRY_LIMIT*: uint64 = 1099511627776'u64
+
+  # Reward and penalty quotients
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.3/configs/mainnet/phase0.yaml#L120
+  BASE_REWARD_FACTOR*: uint64 = 2'u64^6
+  WHISTLEBLOWER_REWARD_QUOTIENT*: uint64 = 2'u64^9
+  PROPOSER_REWARD_QUOTIENT*: uint64 = 2'u64^3
+  INACTIVITY_PENALTY_QUOTIENT*: uint64 = 2'u64^26
+  MIN_SLASHING_PENALTY_QUOTIENT*: uint64 = 128 # 2^5
+  PROPORTIONAL_SLASHING_MULTIPLIER*: uint64 = 1
+
+  # Max operations per block
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.3/configs/mainnet/phase0.yaml#L134
+  MAX_PROPOSER_SLASHINGS*: uint64 = 2'u64 ^ 4
+  MAX_ATTESTER_SLASHINGS*: uint64 = 2'u64 ^ 1
+  MAX_ATTESTATIONS*: uint64 = 2'u64 ^ 7
+  MAX_DEPOSITS*: uint64 = 2'u64 ^ 4
+  MAX_VOLUNTARY_EXITS*: uint64 = 2'u64 ^ 4
+
+  # Fork choice
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.3/configs/mainnet/phase0.yaml#L32
+  SAFE_SLOTS_TO_UPDATE_JUSTIFIED*: uint64 = 8 # 96 seconds
+
+  # Validators
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.3/configs/mainnet/phase0.yaml#L38
+  ETH1_FOLLOW_DISTANCE* {.intdefine.}: uint64 = 2048 # blocks ~ 8 hours
+  TARGET_AGGREGATORS_PER_COMMITTEE*: uint64 = 16 # validators
+  RANDOM_SUBNETS_PER_VALIDATOR*: uint64 = 1 # subnet
+  EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION*: uint64 = 256 # epochs ~ 27 hours
+  SECONDS_PER_ETH1_BLOCK* {.intdefine.}: uint64 = 14 # (estimate from Eth1 mainnet)
+
+  # Deposit contract
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.3/configs/mainnet/phase0.yaml#L52
+
+  # Ethereum PoW Mainnet
+  # TODO These violate the spec (this is a temporary change to allow `make medalla` to work)
+  DEPOSIT_CHAIN_ID* = 5
+  DEPOSIT_NETWORK_ID* = 5

--- a/beacon_chain/spec/presets/v1_0_0-rc_0/minimal.nim
+++ b/beacon_chain/spec/presets/v1_0_0-rc_0/minimal.nim
@@ -1,0 +1,145 @@
+# beacon_chain
+# Copyright (c) 2018-2020 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# This file contains constants that are part of the spec and thus subject to
+# serialization and spec updates.
+
+import
+  math
+
+{.experimental: "codeReordering".} # SLOTS_PER_EPOCH is use before being defined in spec
+
+const
+  # Misc
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.3/configs/minimal/phase0.yaml#L4
+  CONFIG_NAME* = "minimal"
+
+  # Changed
+  MAX_COMMITTEES_PER_SLOT*: uint64 = 4
+  TARGET_COMMITTEE_SIZE*: uint64 = 4
+
+  # Unchanged
+  MAX_VALIDATORS_PER_COMMITTEE*: uint64 = 2048
+  MIN_PER_EPOCH_CHURN_LIMIT*: uint64 = 4
+  CHURN_LIMIT_QUOTIENT*: uint64 = 2'u64 ^ 16
+
+  # Changed
+  SHUFFLE_ROUND_COUNT*: uint64 = 10
+
+  # Unchanged
+  HYSTERESIS_QUOTIENT*: uint64 = 4
+  HYSTERESIS_DOWNWARD_MULTIPLIER*: uint64 = 1
+  HYSTERESIS_UPWARD_MULTIPLIER*: uint64 = 5
+
+  # Gwei values
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.3/configs/minimal/phase0.yaml#L61
+
+  # Changed
+  ETH1_FOLLOW_DISTANCE* {.intdefine.}: uint64 = 16 # blocks
+
+  # Unchanged
+  MIN_DEPOSIT_AMOUNT*: uint64 = 2'u64^0 * 10'u64^9
+  MAX_EFFECTIVE_BALANCE*: uint64 = 2'u64^5 * 10'u64^9
+  EJECTION_BALANCE*: uint64 = 2'u64^4 * 10'u64^9
+  EFFECTIVE_BALANCE_INCREMENT*: uint64 = 2'u64^0 * 10'u64^9
+
+  # Initial values
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.3/configs/minimal/phase0.yaml#L73
+
+  BLS_WITHDRAWAL_PREFIX*: byte = 0
+
+  # Time parameters
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.3/configs/minimal/phase0.yaml#L80
+  # Changed: Faster to spin up testnets, but does not give validator
+  # reasonable warning time for genesis
+
+  # Unchanged
+  SECONDS_PER_SLOT*{.intdefine.}: uint64 = 6
+
+  # Unchanged
+  MIN_ATTESTATION_INCLUSION_DELAY*: uint64 = 1
+
+  # Changed
+  SLOTS_PER_EPOCH* {.intdefine.}: uint64 = 8
+
+  # Unchanged
+  MIN_SEED_LOOKAHEAD*: uint64 = 1
+  MAX_SEED_LOOKAHEAD*: uint64 = 4
+
+  # Changed
+  EPOCHS_PER_ETH1_VOTING_PERIOD*: uint64 = 4
+  SLOTS_PER_HISTORICAL_ROOT*: uint64 = 64
+
+  # Unchanged
+  MIN_VALIDATOR_WITHDRAWABILITY_DELAY*: uint64 = 2'u64^8
+
+  SHARD_COMMITTEE_PERIOD*: uint64 = 64 # epochs
+
+  # Changed
+  MIN_EPOCHS_TO_INACTIVITY_PENALTY*: uint64 = 2'u64^2
+
+  # State vector lengths
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.3/configs/minimal/phase0.yaml#L108
+
+  # Changed
+  EPOCHS_PER_HISTORICAL_VECTOR*: uint64 = 64
+  EPOCHS_PER_SLASHINGS_VECTOR*: uint64 = 64
+
+  # Unchanged
+  HISTORICAL_ROOTS_LIMIT*: uint64 = 16777216
+  VALIDATOR_REGISTRY_LIMIT*: uint64 = 1099511627776'u64
+
+  # Reward and penalty quotients
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.3/configs/minimal/phase0.yaml#L120
+
+  BASE_REWARD_FACTOR*: uint64 = 2'u64^6
+  WHISTLEBLOWER_REWARD_QUOTIENT*: uint64 = 2'u64^9
+  PROPOSER_REWARD_QUOTIENT*: uint64 = 2'u64^3
+  INACTIVITY_PENALTY_QUOTIENT*: uint64 = 2'u64^25
+  MIN_SLASHING_PENALTY_QUOTIENT*: uint64 = 64 # 2^5
+  PROPORTIONAL_SLASHING_MULTIPLIER*: uint64 = 2
+
+  # Max operations per block
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.3/configs/minimal/phase0.yaml#L134
+
+  MAX_PROPOSER_SLASHINGS*: uint64 = 2'u64 ^ 4
+  MAX_ATTESTER_SLASHINGS*: uint64 = 2'u64 ^ 1
+  MAX_ATTESTATIONS*: uint64 = 2'u64 ^ 7
+  MAX_DEPOSITS*: uint64 = 2'u64 ^ 4
+  MAX_VOLUNTARY_EXITS*: uint64 = 2'u64 ^ 4
+
+  # Deposit contract
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.3/configs/minimal/phase0.yaml#L52
+
+  # Ethereum Goerli testnet
+  DEPOSIT_CHAIN_ID* = 5
+  DEPOSIT_NETWORK_ID* = 5
+
+  # Fork choice
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.3/configs/minimal/phase0.yaml#L32
+
+  # Changed
+  SAFE_SLOTS_TO_UPDATE_JUSTIFIED*: uint64 = 2
+
+  # Validators
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.3/configs/minimal/phase0.yaml#L38
+
+  # Unchanged
+  TARGET_AGGREGATORS_PER_COMMITTEE*: uint64 = 16 # validators
+  RANDOM_SUBNETS_PER_VALIDATOR*: uint64 = 1 # subnet
+  EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION*: uint64 = 256 # epochs ~ 27 hours
+  SECONDS_PER_ETH1_BLOCK* {.intdefine.}: uint64 = 14 # estimate from Eth1 mainnet)

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -41,7 +41,7 @@ type Timers = enum
 # TODO confutils is an impenetrable black box. how can a help text be added here?
 cli do(slots = SLOTS_PER_EPOCH * 6,
        validators = SLOTS_PER_EPOCH * 200, # One per shard is minimum
-       attesterRatio {.desc: "ratio of validators that attest in each round"} = 0.73,
+       attesterRatio {.desc: "ratio of validators that attest in each round"} = 0.82,
        blockRatio {.desc: "ratio of slots with blocks"} = 1.0,
        replay = true):
   let

--- a/research/state_sim.nim
+++ b/research/state_sim.nim
@@ -38,7 +38,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
        json_interval = SLOTS_PER_EPOCH,
        write_last_json = false,
        prefix: int = 0,
-       attesterRatio {.desc: "ratio of validators that attest in each round"} = 0.73,
+       attesterRatio {.desc: "ratio of validators that attest in each round"} = 0.82,
        validate = true):
   let
     flags = if validate: {} else: {skipBlsValidation}

--- a/tests/test_interop.nim
+++ b/tests/test_interop.nim
@@ -160,7 +160,10 @@ suiteReport "Interop":
       when const_preset == "minimal":
         "051d1a9c0fb61fce627e3990b930791fd17cb9fa7fb84a9a0051e55bf1759ec8"
       elif const_preset == "mainnet":
-        "ffe85e9b0e3af1b86a177e5b9dc28d5e1237ff5a046482cb45cbd036e918c676"
+        when ETH2_SPEC == "v0.12.3":
+          "ffe85e9b0e3af1b86a177e5b9dc28d5e1237ff5a046482cb45cbd036e918c676"
+        else:
+          "07358d9660c0534e0055201084f6ddd13d418193ec48a451b572cfe2ee6a35c6"
       else:
         "unimplemented"
     check:

--- a/tests/test_state_transition.nim
+++ b/tests/test_state_transition.nim
@@ -107,7 +107,7 @@ suiteReport "Block processing" & preset():
     when const_preset=="minimal":
       # Can take several minutes with mainnet settings
       check:
-        process_slots(state[], Slot(191))
+        process_slots(state[], Slot(191), cache)
 
     # Would need to process more epochs for the attestation to be removed from
     # the state! (per above bug)


### PR DESCRIPTION
By default, this doesn't change things, but it has been tested across all combinations of (v0.12.3/v1.0.0) x (minimal/mainnet).