### PR TITLE
fix db growth on attestation processing

### DIFF
--- a/ncli/ncli.nim
+++ b/ncli/ncli.nim
@@ -110,7 +110,7 @@ proc doSlots(conf: NcliConf) =
   for i in 0'u64..<conf.slot:
     let isEpoch = (stateY[].data.slot + 1).isEpoch
     withTimer(timers[if isEpoch: tApplyEpochSlot else: tApplySlot]):
-      advance_slot(stateY[], {}, cache)
+      doAssert process_slots(stateY[], stateY[].data.slot + 1, cache)
 
   withTimer(timers[tSaveState]):
     SSZ.saveFile(conf.postState, stateY.data)

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -420,7 +420,7 @@ suiteReport "chain DAG finalization tests" & preset():
     # The loop creates multiple branches, which StateCache isn't suitable for
     cache = StateCache()
 
-    advance_slot(prestate[], {}, cache)
+    doAssert process_slots(prestate[], prestate[].data.slot + 1, cache)
 
     # create another block, orphaning the head
     let blck = makeTestBlock(

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -95,7 +95,7 @@ proc addTestBlock*(
     graffiti = default(GraffitiBytes),
     flags: set[UpdateFlag] = {}): SignedBeaconBlock =
   # Create and add a block to state - state will advance by one slot!
-  advance_slot(state, flags, cache)
+  doAssert process_slots(state, state.data.slot + 1, cache, flags)
 
   let
     proposer_index = get_beacon_proposer_index(state.data, cache)


### PR DESCRIPTION
It turns out that we often save lots of states in the database that are
the result of empty slot processing only - here, we make sure to only
save a state if a block follows - this fixes several issues:

* empty slot states are not always pruned leading to state database size
explosion
* storing states is (very) slow which slows down processing in general,
so we should only do it when it's likely to be useful
* attestation processing doesn't get stuck on saving random states that
won't appear in the chain history