### PR TITLE
removed 2 buggy RPC API endpoints - there are 2 well functioning ones in validator_api.nim anyway

### DIFF
--- a/beacon_chain/spec/eth2_apis/beacon_callsigs.nim
+++ b/beacon_chain/spec/eth2_apis/beacon_callsigs.nim
@@ -63,13 +63,8 @@ proc get_v1_config_fork_schedule(): seq[tuple[epoch: uint64, version: Version]]
 proc get_v1_debug_beacon_states_stateId(stateId: string): BeaconState
 
 
-# TODO: delete old stuff
 
-# https://github.com/ethereum/eth2.0-APIs/blob/master/apis/beacon/basic.md
-#
 proc getBeaconHead(): Slot
-proc getBeaconBlock(slot = none(Slot), root = none(Eth2Digest)): BeaconBlock
-proc getBeaconState(slot = none(Slot), root = none(Eth2Digest)): BeaconState
 proc getNetworkPeerId()
 proc getNetworkPeers()
 proc getNetworkEnr()

--- a/docs/the_nimbus_book/src/api.md
+++ b/docs/the_nimbus_book/src/api.md
@@ -42,10 +42,6 @@ curl -d '{"jsonrpc":"2.0","id":"id","method":"getChainHead","params":[] }' -H 'C
 
 ### getSyncing
 
-### getBeaconBlock
-
-### getBeaconState
-
 ### getNetworkPeerId
 
 ### getNetworkPeers


### PR DESCRIPTION
- `getBeaconBlock` => `get_v1_beacon_blocks_blockId`
- `getBeaconState` => `get_v1_debug_beacon_states_stateId`

this PR fixes 2 out of the 3 problems from #1653 - `getSpecPreset` still crashes.