### PR TITLE
bump libp2p; integrate pubsub.ValidationResult into extended validation

### DIFF
--- a/beacon_chain/beacon_node_types.nim
+++ b/beacon_chain/beacon_node_types.nim
@@ -8,7 +8,9 @@ import
   fork_choice/fork_choice_types,
   validator_slashing_protection
 
-export block_pools_types
+from libp2p/protocols/pubsub/pubsub import ValidationResult
+
+export block_pools_types, ValidationResult
 
 const
   ATTESTATION_LOOKBACK* =

--- a/beacon_chain/block_pools/block_pools_types.nim
+++ b/beacon_chain/block_pools/block_pools_types.nim
@@ -14,6 +14,9 @@ import
   ../spec/[datatypes, crypto, digest],
   ../beacon_chain_db, ../extras
 
+from libp2p/protocols/pubsub/pubsub import ValidationResult
+export ValidationResult
+
 # #############################################
 #
 #            Quarantine & DAG

--- a/beacon_chain/eth2_processor.nim
+++ b/beacon_chain/eth2_processor.nim
@@ -242,7 +242,7 @@ proc blockValidator*(
     (afterGenesis, wallSlot) = wallTime.toSlot()
 
   if not afterGenesis:
-    return EVRESULT_IGNORE  # not an issue with block, so don't penalize
+    return ValidationResult.Ignore  # not an issue with block, so don't penalize
 
   logScope: wallSlot
 
@@ -253,7 +253,7 @@ proc blockValidator*(
     # already-seen data, but it is fairly aggressive about forgetting about
     # what it has seen already
     debug "Dropping already-seen gossip block", delay
-    return EVRESULT_IGNORE  # "[IGNORE] The block is the first block with ..."
+    return ValidationResult.Ignore  # "[IGNORE] The block is the first block ..."
 
   # Start of block processing - in reality, we have already gone through SSZ
   # decoding at this stage, which may be significant
@@ -279,7 +279,7 @@ proc blockValidator*(
   traceAsyncErrors self.blocksQueue.addLast(
     BlockEntry(v: SyncBlock(blk: signedBlock)))
 
-  EVRESULT_ACCEPT
+  ValidationResult.Accept
 
 proc attestationValidator*(
     self: var Eth2Processor,
@@ -295,7 +295,7 @@ proc attestationValidator*(
 
   if not afterGenesis:
     notice "Attestation before genesis"
-    return EVRESULT_IGNORE
+    return ValidationResult.Ignore
 
   logScope: wallSlot
 
@@ -321,7 +321,7 @@ proc attestationValidator*(
   traceAsyncErrors self.attestationsQueue.addLast(
     AttestationEntry(v: attestation, attesting_indices: v.get()))
 
-  EVRESULT_ACCEPT
+  ValidationResult.Accept
 
 proc aggregateValidator*(
     self: var Eth2Processor,
@@ -336,7 +336,7 @@ proc aggregateValidator*(
 
   if not afterGenesis:
     notice "Aggregate before genesis"
-    return EVRESULT_IGNORE
+    return ValidationResult.Ignore
 
   logScope: wallSlot
 
@@ -365,7 +365,7 @@ proc aggregateValidator*(
     v: signedAggregateAndProof.message.aggregate,
     attesting_indices: v.get()))
 
-  EVRESULT_ACCEPT
+  ValidationResult.Accept
 
 proc attesterSlashingValidator*(
     self: var Eth2Processor, attesterSlashing: AttesterSlashing):
@@ -380,7 +380,7 @@ proc attesterSlashingValidator*(
 
   beacon_attester_slashings_received.inc()
 
-  EVRESULT_ACCEPT
+  ValidationResult.Accept
 
 proc proposerSlashingValidator*(
     self: var Eth2Processor, proposerSlashing: ProposerSlashing):
@@ -395,7 +395,7 @@ proc proposerSlashingValidator*(
 
   beacon_proposer_slashings_received.inc()
 
-  EVRESULT_ACCEPT
+  ValidationResult.Accept
 
 proc voluntaryExitValidator*(
     self: var Eth2Processor, signedVoluntaryExit: SignedVoluntaryExit):
@@ -410,7 +410,7 @@ proc voluntaryExitValidator*(
 
   beacon_voluntary_exits_received.inc()
 
-  EVRESULT_ACCEPT
+  ValidationResult.Accept
 
 proc runQueueProcessingLoop*(self: ref Eth2Processor) {.async.} =
   # Blocks in eth2 arrive on a schedule for every slot:

--- a/beacon_chain/exit_pool.nim
+++ b/beacon_chain/exit_pool.nim
@@ -161,7 +161,7 @@ proc validateAttesterSlashing*(
       attester_slashed_indices, pool.prior_seen_attester_slashed_indices):
     const err_str: cstring =
       "validateAttesterSlashing: attester-slashed index already attester-slashed"
-    return err((EVRESULT_IGNORE, err_str))
+    return err((ValidationResult.Ignore, err_str))
 
   # [REJECT] All of the conditions within process_attester_slashing pass
   # validation.
@@ -172,7 +172,7 @@ proc validateAttesterSlashing*(
     check_attester_slashing(
       pool.chainDag.headState.data.data, attester_slashing, {}, cache)
   if attester_slashing_validity.isErr:
-    return err((EVRESULT_REJECT, attester_slashing_validity.error))
+    return err((ValidationResult.Reject, attester_slashing_validity.error))
 
   pool.prior_seen_attester_slashed_indices.incl attester_slashed_indices
   pool.attester_slashings.addExitMessage(
@@ -191,7 +191,7 @@ proc validateProposerSlashing*(
       pool.prior_seen_proposer_slashed_indices:
     const err_str: cstring =
       "validateProposerSlashing: proposer-slashed index already proposer-slashed"
-    return err((EVRESULT_IGNORE, err_str))
+    return err((ValidationResult.Ignore, err_str))
 
   # [REJECT] All of the conditions within process_proposer_slashing pass validation.
   var cache =
@@ -201,7 +201,7 @@ proc validateProposerSlashing*(
     check_proposer_slashing(
       pool.chainDag.headState.data.data, proposer_slashing, {}, cache)
   if proposer_slashing_validity.isErr:
-    return err((EVRESULT_REJECT, proposer_slashing_validity.error))
+    return err((ValidationResult.Reject, proposer_slashing_validity.error))
 
   pool.prior_seen_proposer_slashed_indices.incl(
     proposer_slashing.signed_header_1.message.proposer_index)
@@ -219,11 +219,11 @@ proc validateVoluntaryExit*(
   if signed_voluntary_exit.message.validator_index >=
       pool.chainDag.headState.data.data.validators.lenu64:
     const err_str: cstring = "validateVoluntaryExit: validator index too high"
-    return err((EVRESULT_IGNORE, err_str))
+    return err((ValidationResult.Ignore, err_str))
   if signed_voluntary_exit.message.validator_index in
       pool.prior_seen_voluntary_exit_indices:
     const err_str: cstring = "validateVoluntaryExit: validator index already voluntarily exited"
-    return err((EVRESULT_IGNORE, err_str))
+    return err((ValidationResult.Ignore, err_str))
 
   # [REJECT] All of the conditions within process_voluntary_exit pass
   # validation.
@@ -234,7 +234,7 @@ proc validateVoluntaryExit*(
     check_voluntary_exit(
       pool.chainDag.headState.data.data, signed_voluntary_exit, {}, cache)
   if voluntary_exit_validity.isErr:
-    return err((EVRESULT_REJECT, voluntary_exit_validity.error))
+    return err((ValidationResult.Reject, voluntary_exit_validity.error))
 
   pool.prior_seen_voluntary_exit_indices.incl(
     signed_voluntary_exit.message.validator_index)

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -458,12 +458,6 @@ type
     stabilitySubnet*: uint64
     stabilitySubnetExpirationEpoch*: Epoch
 
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.3/specs/phase0/p2p-interface.md#topics-and-messages
-  ValidationResult* = enum
-    EVRESULT_ACCEPT = 0
-    EVRESULT_REJECT = 1
-    EVRESULT_IGNORE = 2
-
 func shortValidatorKey*(state: BeaconState, validatorIdx: int): string =
   ($state.validators[validatorIdx].pubkey)[0..7]
 

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -304,7 +304,7 @@ suiteReport "Attestation pool processing" & preset():
         # Callback add to fork choice if valid
         pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
 
-    doAssert: b10Add_clone.error == (EVRESULT_IGNORE, Duplicate)
+    doAssert: b10Add_clone.error == (ValidationResult.Ignore, Duplicate)
 
   wrappedTimedTest "Trying to add a duplicate block from an old pruned epoch is tagged as an error":
     # Note: very sensitive to stack usage
@@ -388,7 +388,7 @@ suiteReport "Attestation pool processing" & preset():
         # Callback add to fork choice if valid
         pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
 
-    doAssert: b10Add_clone.error == (EVRESULT_IGNORE, Duplicate)
+    doAssert: b10Add_clone.error == (ValidationResult.Ignore, Duplicate)
 
 
 suiteReport "Attestation validation " & preset():
@@ -443,7 +443,7 @@ suiteReport "Attestation validation " & preset():
 
       # Same validator again
       validateAttestation(pool[], attestation, beaconTime, subnet).error()[0] ==
-        EVRESULT_IGNORE
+        ValidationResult.Ignore
 
     pool[].lastVotedEpoch.setLen(0) # reset for test
     check:

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -221,7 +221,7 @@ suiteReport "Block pool processing" & preset():
 
   wrappedTimedTest "Reverse order block add & get" & preset():
     let missing = dag.addRawBlock(quarantine, b2, nil)
-    check: missing.error == (EVRESULT_IGNORE, MissingParent)
+    check: missing.error == (ValidationResult.Ignore, MissingParent)
 
     check:
       dag.get(b2.root).isNone() # Unresolved, shouldn't show up
@@ -267,7 +267,7 @@ suiteReport "Block pool processing" & preset():
       b11 = dag.addRawBlock(quarantine, b1, nil)
 
     check:
-      b11.error == (EVRESULT_IGNORE, Duplicate)
+      b11.error == (ValidationResult.Ignore, Duplicate)
       not b10[].isNil
 
   wrappedTimedTest "updateHead updates head and headState" & preset():
@@ -402,7 +402,7 @@ suiteReport "chain DAG finalization tests" & preset():
       # The late block is a block whose parent was finalized long ago and thus
       # is no longer a viable head candidate
       let status = dag.addRawBlock(quarantine, lateBlock, nil)
-      check: status.error == (EVRESULT_IGNORE, Unviable)
+      check: status.error == (ValidationResult.Ignore, Unviable)
 
     let
       dag2 = init(ChainDAGRef, defaultRuntimePreset, db)


### PR DESCRIPTION
The bulk of the changes are just search/replace:
- `s/EVRESULT_IGNORE/ValidationResult.Ignore/`
- `s/EVRESULT_REJECT/ValidationResult.Reject/`
- `s/EVRESULT_ACCEPT/ValidationResult.Accept/`

This requires this updated libp2p, and conversely, this updated libp2p requires changes along these lines.