### PR TITLE
Syncing fixes

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -657,22 +657,20 @@ proc startSyncManager(node: BeaconNode) =
 
   proc scoreCheck(peer: Peer): bool =
     if peer.score < PeerScoreLowLimit:
-      try:
-        debug "Peer score is too low, disconnecting", peer = peer,
-              peer_score = peer.score, score_low_limit = PeerScoreLowLimit,
-              score_high_limit = PeerScoreHighLimit
-        # We do not care about result of this operation, because even if
-        # disconnect operation fails, peer will still be added to SeenTable
-        # and removed from PeerPool. So it will be not reused for syncing for
-        # `SeenTablePenaltyError` time.
-        asyncSpawn peer.disconnect(PeerScoreLow)
-      except:
-        discard
+      debug "Peer score is too low", peer = peer,
+            peer_score = peer.score, score_low_limit = PeerScoreLowLimit,
+            score_high_limit = PeerScoreHighLimit
       false
     else:
       true
 
+  proc onDeletePeer(peer: Peer) =
+    debug "Peer is got removed from PeerPool, disconnecting", peer = peer,
+          peer_score = peer.score
+    asyncSpawn peer.disconnect(PeerScoreLow)
+
   node.network.peerPool.setScoreCheck(scoreCheck)
+  node.network.peerPool.setOnDeletePeer(onDeletePeer)
 
   node.syncManager = newSyncManager[Peer, PeerID](
     node.network.peerPool, getLocalHeadSlot, getLocalWallSlot,

--- a/beacon_chain/peer_pool.nim
+++ b/beacon_chain/peer_pool.nim
@@ -32,6 +32,8 @@ type
 
   PeerCounterCallback* = proc() {.gcsafe, raises: [Defect].}
 
+  PeerOnDeleteCallback*[T] = proc(peer: T) {.gcsafe.}
+
   PeerPool*[A, B] = ref object
     incNotEmptyEvent*: AsyncEvent
     outNotEmptyEvent*: AsyncEvent
@@ -43,6 +45,7 @@ type
     storage: seq[PeerItem[A]]
     cmp: proc(a, b: PeerIndex): bool {.closure, gcsafe.}
     scoreCheck: PeerScoreCheckCallback[A]
+    onDeletePeer: PeerOnDeleteCallback[A]
     peerCounter: PeerCounterCallback
     maxPeersCount: int
     maxIncPeersCount: int
@@ -132,7 +135,8 @@ proc waitNotFullEvent[A, B](pool: PeerPool[A, B],
 proc newPeerPool*[A, B](maxPeers = -1, maxIncomingPeers = -1,
                         maxOutgoingPeers = -1,
                         scoreCheckCb: PeerScoreCheckCallback[A] = nil,
-                        peerCounterCb: PeerCounterCallback = nil): PeerPool[A, B] =
+                        peerCounterCb: PeerCounterCallback = nil,
+                    onDeleteCb: PeerOnDeleteCallback[A] = nil): PeerPool[A, B] =
   ## Create new PeerPool.
   ##
   ## ``maxPeers`` - maximum number of peers allowed. All the peers which
@@ -153,6 +157,8 @@ proc newPeerPool*[A, B](maxPeers = -1, maxIncomingPeers = -1,
   ##
   ## ``peerCountCb`` - callback to be called when number of peers in PeerPool
   ## has been changed.
+  ##
+  ## ``onDeleteCb`` - callback to be called when peer is leaving PeerPool.
   ##
   ## Please note, that if ``maxPeers`` is positive non-zero value, then equation
   ## ``maxPeers >= maxIncomingPeers + maxOutgoingPeers`` must be ``true``.
@@ -181,6 +187,7 @@ proc newPeerPool*[A, B](maxPeers = -1, maxIncomingPeers = -1,
   res.registry = initTable[B, PeerIndex]()
   res.scoreCheck = scoreCheckCb
   res.peerCounter = peerCounterCb
+  res.onDeletePeer = onDeleteCb
   res.storage = newSeq[PeerItem[A]]()
 
   proc peerCmp(a, b: PeerIndex): bool {.closure, gcsafe.} =
@@ -265,6 +272,11 @@ proc peerCountChanged[A, B](pool: PeerPool[A, B]) {.inline.} =
   if not(isNil(pool.peerCounter)):
     pool.peerCounter()
 
+proc peerDeleted[A, B](pool: PeerPool[A, B], peer: A) {.inline.} =
+  ## Call callback when peer is leaving PeerPool.
+  if not(isNil(pool.onDeletePeer)):
+    pool.onDeletePeer(peer)
+
 proc deletePeer*[A, B](pool: PeerPool[A, B], peer: A, force = false): bool =
   ## Remove ``peer`` from PeerPool ``pool``.
   ##
@@ -292,6 +304,7 @@ proc deletePeer*[A, B](pool: PeerPool[A, B], peer: A, force = false): bool =
         # Cleanup storage with default item, and removing key from hashtable.
         pool.storage[pindex] = PeerItem[A]()
         pool.registry.del(key)
+        pool.peerDeleted(peer)
         pool.peerCountChanged()
     else:
       if item[].peerType == PeerType.Incoming:
@@ -316,6 +329,7 @@ proc deletePeer*[A, B](pool: PeerPool[A, B], peer: A, force = false): bool =
       # Cleanup storage with default item, and removing key from hashtable.
       pool.storage[pindex] = PeerItem[A]()
       pool.registry.del(key)
+      pool.peerDeleted(peer)
       pool.peerCountChanged()
     true
   else:
@@ -718,10 +732,15 @@ proc clearSafe*[A, B](pool: PeerPool[A, B]) {.async.} =
 
 proc setScoreCheck*[A, B](pool: PeerPool[A, B],
                           scoreCheckCb: PeerScoreCheckCallback[A]) =
-  ## Add ScoreCheck callback.
+  ## Sets ScoreCheck callback.
   pool.scoreCheck = scoreCheckCb
+
+proc setOnDeletePeer*[A, B](pool: PeerPool[A, B],
+                            deletePeerCb: PeerOnDeleteCallback[A]) =
+  ## Sets DeletePeer callback.
+  pool.onDeletePeer = deletePeerCb
 
 proc setPeerCounter*[A, B](pool: PeerPool[A, B],
                            peerCounterCb: PeerCounterCallback) =
-  ## Add PeerCounter callback.
+  ## Sets PeerCounter callback.
   pool.peerCounter = peerCounterCb


### PR DESCRIPTION
1. Fix continous sync queue resets on slow PCs. (address issue #1647)
2. Fix recurring calls to disconnect on peer's score check.
3. Calculate average syncing speed instead of instantaneous syncing speed.