### PR TITLE
Bls signature v4

### DIFF
--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -88,7 +88,9 @@ func toPubKey*(privkey: ValidatorPrivKey): ValidatorPubKey =
   ## Create a private key from a public key
   # Un-specced in either hash-to-curve or Eth2
   # TODO: Test suite should use `keyGen` instead
-  ValidatorPubKey(kind: Real, blsValue: SecretKey(privkey).privToPub())
+  result.kind = Real
+  let ok = result.blsValue.publicFromSecret(SecretKey privkey)
+  doAssert ok, "The validator private key was a zero key. This should never happen."
 
 proc toRealPubKey(pubkey: ValidatorPubKey): Option[ValidatorPubKey] =
   var validatorKeyCache {.threadvar.}:


### PR DESCRIPTION
This upgrades the repo to support the full BLS v04 signatures:

## Specs

- Diff v03 and v04: https://tools.ietf.org/rfcdiff?url1=https://tools.ietf.org/id/draft-irtf-cfrg-bls-signature-03.txt&url2=https://tools.ietf.org/id/draft-irtf-cfrg-bls-signature-04.txt
- Ethereum specs: https://github.com/ethereum/eth2.0-specs/pull/2080

## Upstream

https://github.com/status-im/nim-blscurve/pull/91