### PR TITLE
Some syncing fixes

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -648,9 +648,7 @@ proc startSyncManager(node: BeaconNode) =
     node.chainDag.head.slot
 
   proc getLocalWallSlot(): Slot =
-    let epoch = node.beaconClock.now().slotOrZero.compute_epoch_at_slot() +
-                1'u64
-    epoch.compute_start_slot_at_epoch()
+    node.beaconClock.now().slotOrZero
 
   func getFirstSlotAtFinalizedEpoch(): Slot =
     node.chainDag.finalizedHead.slot

--- a/beacon_chain/sync_manager.nim
+++ b/beacon_chain/sync_manager.nim
@@ -541,7 +541,9 @@ proc push*[T](sq: SyncQueue[T], sr: SyncRequest[T],
           let rewindSlot = sq.getRewindPoint(failSlot.get(), finalizedSlot)
           warn "Unexpected missing parent, rewind happens",
                peer = req.item, rewind_to_slot = rewindSlot,
-               fail_slot = failSlot.get(), finalized_slot = finalized_slot,
+               rewind_epoch_count = sq.rewind.get().epochCount,
+               rewind_fail_slot = failSlot.get(),
+               finalized_slot = finalized_slot,
                request_slot = req.slot, request_count = req.count,
                request_step = req.step, blocks_count = len(item.data),
                blocks_map = getShortMap(req, item.data), topics = "syncman"

--- a/beacon_chain/sync_protocol.nim
+++ b/beacon_chain/sync_protocol.nim
@@ -206,7 +206,7 @@ p2pProtocol BeaconSync(version = 1,
     debug "Received Goodbye message", reason = disconnectReasonName(reason), peer
 
 proc setStatusMsg(peer: Peer, statusMsg: StatusMsg) =
-  trace "Peer status", peer, statusMsg
+  debug "Peer status", peer, statusMsg
   peer.state(BeaconSync).statusMsg = statusMsg
   peer.state(BeaconSync).statusLastTime = Moment.now()
 


### PR DESCRIPTION
1. Introduce exponential rewind on `MissingParent` errors (should help with jokers while at non-finalization hole).
2. Detect and avoid usage of peers which latest head is lower then ours.
3. Fix getLocalWallSlot().
4. Fix SyncQueue recovery after pause.