### PR TITLE
set file and dir permissions

### DIFF
--- a/beacon_chain/filepath.nim
+++ b/beacon_chain/filepath.nim
@@ -14,9 +14,9 @@ proc secureCreatePath*(path: string): IoResult[void] =
       err(sres.error)
     else:
       var sd = sres.get()
-      createPath(path, 0o750, secDescriptor = sd.getDescriptor())
+      createPath(path, 0o700, secDescriptor = sd.getDescriptor())
   else:
-    createPath(path, 0o750)
+    createPath(path, 0o700)
 
 proc secureWriteFile*[T: byte|char](path: string,
                                     data: openArray[T]): IoResult[void] =

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -161,7 +161,7 @@ if [[ "$REUSE_EXISTING_DATA_DIR" == "0" ]]; then
   rm -rf "${DATA_DIR}"
 fi
 
-mkdir -m 0750 -p "${DATA_DIR}"
+mkdir -m 0700 -p "${DATA_DIR}"
 
 DEPOSITS_FILE="${DATA_DIR}/deposits.json"
 
@@ -341,7 +341,7 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
   # The first $NODES_WITH_VALIDATORS nodes split them equally between them, after skipping the first $USER_VALIDATORS.
   NODE_DATA_DIR="${DATA_DIR}/node${NUM_NODE}"
   rm -rf "${NODE_DATA_DIR}"
-  mkdir -m 0750 -p "${NODE_DATA_DIR}"
+  mkdir -m 0700 -p "${NODE_DATA_DIR}"
   mkdir -p "${NODE_DATA_DIR}/validators"
   mkdir -p "${NODE_DATA_DIR}/secrets"
 

--- a/scripts/makedir.sh
+++ b/scripts/makedir.sh
@@ -24,7 +24,7 @@ if [[ "${ON_WINDOWS}" == "1" ]]; then
     icacls "$1" /inheritance:r /grant:r $USERDOMAIN\\$USERNAME:\(OI\)\(CI\)\(F\)&>/dev/null;
   fi
 else
-  # Create full path with 0750 permissions.
-  mkdir -m 0750 -p "$1"
+  # Create full path with proper permissions.
+  mkdir -m 0700 -p $1
 fi
 


### PR DESCRIPTION
- get rid of group read and execute permissions for directories; there is no justification for allowing that
- set the desired permissions instead of exiting the program - fixes https://github.com/status-im/nimbus-eth2/issues/1921
- don't call the POSIX `access()` function, since it doesn't do anything we need. https://man7.org/linux/man-pages/man2/access.2.html :

`In other words, access() does not answer the "can I read/write/execute this file?" question.  It answers a slightly different
question: "(assuming I'm a setuid binary) can the user who invoked me read/write/execute this file?", which gives set-user-ID
programs the possibility to prevent malicious users from causing them to read files which users shouldn't be able to read.`