### PR TITLE
tone down validator exit logging

### DIFF
--- a/beacon_chain/block_pools/chain_dag.nim
+++ b/beacon_chain/block_pools/chain_dag.nim
@@ -802,17 +802,11 @@ proc updateHead*(
     lastHead = dag.head
   dag.db.putHeadBlock(newHead.root)
 
-  # Start off by making sure we have the right state - as a special case, we'll
-  # check the last block that was cleared by clearance - it might be just the
-  # thing we're looking for
-
-  if dag.clearanceState.blck == newHead and
-      dag.clearanceState.data.data.slot == newHead.slot:
-    assign(dag.headState, dag.clearanceState)
-  else:
-    var cache = getStateCache(newHead, newHead.slot.epoch())
-    updateStateData(
-      dag, dag.headState, newHead.atSlot(newHead.slot), false, cache)
+  # Start off by making sure we have the right state - updateStateData will try
+  # to use existing in-memory states to make this smooth
+  var cache: StateCache
+  updateStateData(
+    dag, dag.headState, newHead.atSlot(newHead.slot), false, cache)
 
   dag.head = newHead
 

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -34,10 +34,6 @@ import
   ./signatures, ./presets,
   ../../nbench/bench_lab
 
-# https://github.com/ethereum/eth2.0-metrics/blob/master/metrics.md#additional-metrics
-declareGauge beacon_current_live_validators, "Number of active validators that successfully included attestation on chain for current epoch" # On block
-declareGauge beacon_previous_live_validators, "Number of active validators that successfully included attestation on chain for previous epoch" # On block
-
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0-rc.0/specs/phase0/beacon-chain.md#block-header
 func process_block_header*(
     state: var BeaconState, blck: SomeBeaconBlock, flags: UpdateFlags,
@@ -355,17 +351,8 @@ proc process_block*(
     state: var BeaconState, blck: SomeBeaconBlock, flags: UpdateFlags,
     stateCache: var StateCache): bool {.nbench.}=
   ## When there's a new block, we need to verify that the block is sane and
-  ## update the state accordingly
-
-  # TODO when there's a failure, we should reset the state!
-  # TODO probably better to do all verification first, then apply state changes
-
-  # Adds nontrivial additional computation, but only does so when metrics
-  # enabled.
-  beacon_current_live_validators.set(toHashSet(
-    mapIt(state.current_epoch_attestations, it.proposerIndex)).len.int64)
-  beacon_previous_live_validators.set(toHashSet(
-    mapIt(state.previous_epoch_attestations, it.proposerIndex)).len.int64)
+  ## update the state accordingly - the state is left in an unknown state when
+  ## block application fails (!)
 
   logScope:
     blck = shortLog(blck)


### PR DESCRIPTION
Validators exiting is normal, no need to scream about it

* avoid reallocating seq on big exit queue
* avoid fetching state cache when updating head (it's rarely needed)
* remove incorrectly implemented live validator counts (avoids memory
allocs)