### PR TITLE
Revert "Gossip11 post audit (#1917)"

### DIFF
--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -26,8 +26,10 @@ import
   peer_pool, spec/[datatypes, digest, helpers, network], ./time,
   keystore_management
 
-# gossipsub 1.1
-import libp2p/protocols/pubsub/gossipsub
+when defined(nbc_gossipsub_11):
+  import libp2p/protocols/pubsub/gossipsub
+else:
+  import libp2p/protocols/pubsub/gossipsub10
 
 when chronicles.enabledLogLevel == LogLevel.TRACE:
   import std/sequtils


### PR DESCRIPTION
This reverts commit 63173ab2c1767549cef3d0774375190a4a455478.

It appears the cluster is having trouble staying connected - since the culprit is unknown, this is a first step on the way to what was stable.

Notably, this does not fully revert libp2p itself, merely the gossip version.