### PR TITLE
dist: build on Ubuntu 20.04 (LTS)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -427,4 +427,13 @@ dist:
 	ls -l dist
 	$(MAKE) clean
 
+#- this simple test will show any missing dynamically-linked Glibc symbols in the target distro
+dist-test:
+	docker rm nimbus-eth2-dist-test $(HANDLE_OUTPUT) || true
+	cd docker/dist && \
+		for DISTRO in debian-bullseye; do \
+			DOCKER_BUILDKIT=1 docker build -f Dockerfile.$${DISTRO} -t nimbus-eth2-dist-test --progress=plain --build-arg USER_ID=$$(id -u) --build-arg GROUP_ID=$$(id -g) . && \
+			docker run --rm --name nimbus-eth2-dist-test -v $(CURDIR):/home/user/nimbus-eth2 nimbus-eth2-dist-test; \
+		done
+
 endif # "variables.mk" was not included

--- a/README.md
+++ b/README.md
@@ -495,6 +495,12 @@ make publish-book
 make dist
 ```
 
+- test the binaries
+
+```bash
+make dist-test
+```
+
 ### CI setup
 
 Local testnets run for 4 epochs each, to test finalization. That happens only on Jenkins Linux hosts, and their logs are available for download as artifacts, from the job's page. Don't expect these artifacts to be kept more than a day after the corresponding branch is deleted.

--- a/docker/dist/Dockerfile
+++ b/docker/dist/Dockerfile
@@ -1,5 +1,5 @@
 # The build is reproducible only if this base image stays the same.
-FROM  statusteam/nimbus_beacon_node:dist_base_20201008172919@sha256:7190a4d54e56aa4a45fa3032381a43dcec89f23e6d7ed5dfb0f98967f92bf522
+FROM statusteam/nimbus_beacon_node:dist_base_20201103201341@sha256:25510b42e7573450bd0a2bbfa4c331e3345b80bee8b96a7e60621949b6154f7f
 
 SHELL ["/bin/bash", "-c"]
 

--- a/docker/dist/Dockerfile.debian-bullseye
+++ b/docker/dist/Dockerfile.debian-bullseye
@@ -1,0 +1,17 @@
+FROM debian:bullseye-slim
+
+SHELL ["/bin/bash", "-c"]
+
+ARG USER_ID
+ARG GROUP_ID
+
+RUN addgroup --gid ${GROUP_ID} user; \
+	adduser --disabled-password --gecos '' --uid ${USER_ID} --gid ${GROUP_ID} user;
+
+USER user
+
+STOPSIGNAL SIGINT
+
+COPY "entry_point_test.sh" "/home/user/"
+ENTRYPOINT ["/home/user/entry_point_test.sh"]
+

--- a/docker/dist/base_image/Dockerfile
+++ b/docker/dist/base_image/Dockerfile
@@ -1,12 +1,12 @@
 # This Docker image can change from one build to another, because the upstream
-# Debian package index is continuously updated and we have to run `apt-get
-# update` in here.
+# Debian/Ubuntu package index is continuously updated and we have to run
+# `apt-get update` in here.
 #
 # The only way to make this a part of our reproducible build system is to build
 # it once, upload it to Docker Hub and make sure it's being pulled regularly so
 # it's not deleted after 6 months of inactivity.
 
-FROM debian:bullseye-slim
+FROM ubuntu:20.04
 
 SHELL ["/bin/bash", "-c"]
 

--- a/docker/dist/entry_point_test.sh
+++ b/docker/dist/entry_point_test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+cd /home/user/nimbus-eth2
+
+PREFIX="nimbus-eth2_Linux_amd64_"
+
+NUM_ARCHIVES=$(ls "dist/${PREFIX}"*.tar.gz 2>/dev/null | wc -l)
+if [[ $NUM_ARCHIVES -eq 0 ]]; then
+  echo "No archive found matching \"dist/${PREFIX}*.tar.gz\". Aborting."
+  exit 1
+elif [[ $NUM_ARCHIVES -gt 1 ]]; then
+  echo "More than one archive found matching \"dist/${PREFIX}*.tar.gz\". Aborting."
+  exit 1
+fi
+
+cd dist
+ARCHIVE=$(echo ${PREFIX}*.tar.gz)
+ARCHIVE_DIR="${ARCHIVE%.tar.gz}"
+rm -rf ${ARCHIVE_DIR}
+tar xzf "${ARCHIVE}"
+cd "${ARCHIVE_DIR}"
+./beacon_node --help
+cd ..
+rm -rf ${ARCHIVE_DIR}
+


### PR DESCRIPTION
And a new Make target: "dist-test" - it simply runs the beacon_node binary produced by "make dist", with "--help", inside a Debian Bullseye image.