### PR TITLE
Store block summary in database

### DIFF
--- a/beacon_chain/block_pools/chain_dag.nim
+++ b/beacon_chain/block_pools/chain_dag.nim
@@ -334,14 +334,14 @@ proc init*(T: type ChainDAGRef,
   if headRoot != tailRoot:
     var curRef: BlockRef
 
-    for blck in db.getAncestors(headRoot):
+    for blck in db.getAncestorSummaries(headRoot):
       if blck.root == tailRef.root:
         doAssert(not curRef.isNil)
         link(tailRef, curRef)
         curRef = curRef.parent
         break
 
-      let newRef = BlockRef.init(blck.root, blck.message)
+      let newRef = BlockRef.init(blck.root, blck.summary.slot)
       if curRef == nil:
         curRef = newRef
         headRef = newRef

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -99,20 +99,32 @@ suiteReport "Beacon chain DB" & preset():
     doAssert toSeq(db.getAncestors(a0.root)) == []
     doAssert toSeq(db.getAncestors(a2.root)) == []
 
+    doAssert toSeq(db.getAncestorSummaries(a0.root)).len == 0
+    doAssert toSeq(db.getAncestorSummaries(a2.root)).len == 0
+
     db.putBlock(a2)
 
     doAssert toSeq(db.getAncestors(a0.root)) == []
     doAssert toSeq(db.getAncestors(a2.root)) == [a2]
+
+    doAssert toSeq(db.getAncestorSummaries(a0.root)).len == 0
+    doAssert toSeq(db.getAncestorSummaries(a2.root)).len == 1
 
     db.putBlock(a1)
 
     doAssert toSeq(db.getAncestors(a0.root)) == []
     doAssert toSeq(db.getAncestors(a2.root)) == [a2, a1]
 
+    doAssert toSeq(db.getAncestorSummaries(a0.root)).len == 0
+    doAssert toSeq(db.getAncestorSummaries(a2.root)).len == 2
+
     db.putBlock(a0)
 
     doAssert toSeq(db.getAncestors(a0.root)) == [a0]
     doAssert toSeq(db.getAncestors(a2.root)) == [a2, a1, a0]
+
+    doAssert toSeq(db.getAncestorSummaries(a0.root)).len == 1
+    doAssert toSeq(db.getAncestorSummaries(a2.root)).len == 3
 
   wrappedTimedTest "sanity check genesis roundtrip" & preset():
     # This is a really dumb way of checking that we can roundtrip a genesis


### PR DESCRIPTION
This introcudes a cache for block summaries, useful for instantiating
the block dag on startup, bringing medalla startup times down from
minutes to seconds.

This is something of a temporary band-aid that would be obsoleted by a
finalized block store.