### PR TITLE
Update book for mainnet

### DIFF
--- a/docs/the_nimbus_book/src/SUMMARY.md
+++ b/docs/the_nimbus_book/src/SUMMARY.md
@@ -1,5 +1,6 @@
 # Summary
 - [Introduction](./intro.md)
+- [Hardware requirements]()
 - [Install dependencies](./install.md)
 - [Build the beacon node](./build.md)
 - [Start syncing](./start-syncing.md)
@@ -7,7 +8,7 @@
 - [Manage your keys](./keys.md)
 - [Connect to eth2](./connect-eth2.md)
 - [Keep an eye on your validator](./keep-an-eye.md)
-- [Keep your validator updated](./keep-updated.md)
+- [Keep Nimbus updated](./keep-updated.md)
 - [Useful pre-genesis checks]()
 # Volume 2
 - [Troubleshooting](./troubleshooting.md)

--- a/docs/the_nimbus_book/src/connect-eth2.md
+++ b/docs/the_nimbus_book/src/connect-eth2.md
@@ -1,5 +1,7 @@
 # Connect to eth2
 
+> ⚠️  This page concerns the Medalla testnet only. If you have made a mainnet deposit, you do not need to connect to eth2 quite yet. Mainnet [Genesis](https://hackmd.io/@benjaminion/genesis) date has been set to [December 1st](https://blog.ethereum.org/2020/11/04/eth2-quick-update-no-19/). This page will be updated nearer the time.
+
 To connect to the Medalla testnet, from the `nimbus-eth2` repository run:
 
 ```

--- a/docs/the_nimbus_book/src/create-wallet-and-deposit.md
+++ b/docs/the_nimbus_book/src/create-wallet-and-deposit.md
@@ -1,6 +1,8 @@
 # Generate your keys with Nimbus
 
-On this page, we'll take you through how to create an [EIP-2386](https://github.com/ethereum/EIPs/blob/4494da0966afa7318ec0157948821b19c4248805/EIPS/eip-2386.md) wallet to help you generate your validator keys (keystores), create a `deposits_data` file compatible with the Ethereum Foundation's [Validator Launchpad](https://medalla.launchpad.ethereum.org/), and use the launchpad to send this data to the eth1 network so that your validator can be registered.
+> ⚠️  This page concerns the Medalla testnet. DO NOT USE THIS PAGE TO GENERATE KEYS FOR MAINNET. Please use the [Ethereum Foundation's Launchpad](https://launchpad.ethereum.org/) instead. 
+
+On this page, we'll take you through how to create an [EIP-2386](https://github.com/ethereum/EIPs/blob/4494da0966afa7318ec0157948821b19c4248805/EIPS/eip-2386.md) wallet to help you generate your validator keys (keystores), create a `deposits_data` file compatible with the Ethereum Foundation's [Medalla Launchpad](https://medalla.launchpad.ethereum.org/), and use the launchpad to send this data to the eth1 network so that your validator can be registered.
 
 
 > **Note:** this page is primarily aimed at users who wish to run multiple validators on several machines. If you simply wish to get one validator up and running with Nimbus, or run several validators on a single machine, we recommend following our [become a Medalla validator](./medalla.md) guide instead.

--- a/docs/the_nimbus_book/src/deposit.md
+++ b/docs/the_nimbus_book/src/deposit.md
@@ -1,9 +1,15 @@
 # Make a deposit
- 
 The easiest way to get your deposit in is to follow the Ethereum Foundation's launchpad instructions here:
- 
-[https://medalla.launchpad.ethereum.org/](https://zinken.launchpad.ethereum.org/)
- 
+
+**Testnet**:
+[https://medalla.launchpad.ethereum.org/](https://medalla.launchpad.ethereum.org/)
+
+**Mainnet**: [https://launchpad.ethereum.org/](https://launchpad.ethereum.org/)
+
+> ⚠️ : If you are making a mainnet deposit make sure you verify that the deposit contract you are interacting with is the correct one. 
+>
+> You should verify that the address is indeed: [0x00000000219ab540356cBB839Cbe05303d7705Fa](https://etherscan.io/address/0x00000000219ab540356cBB839Cbe05303d7705Fa)
+
 You may notice that there have been considerable improvements to the launchpad process since the summer.
  
 In particular, the Key Generation section is now much clearer, and you no longer have to install dependencies to get the command line app working.
@@ -34,6 +40,7 @@ We recommend you click on `Beaconchain`. This will open up a window that allows 
 
 It's a good idea to bookmark this page.
 
-## A note on expected waiting time (the queue)
-Once you send off your transaction(s), your validator will be put in a queue based on deposit time, and will getting through the queue may take a few hours or days (assuming the chain is finalising).
+## Expected waiting time (the queue)
+Once you send off your transaction(s), your validator will be put in a queue based on deposit time. Getting through the queue may take a few hours or days (assuming the chain is finalising). No validators are accepted into the validator set while the chain isn't finalising.
 
+> **Note:** If you are making a mainnet deposit this is all you need to do at this stage. If you haven't done so already, we recommend you make a testnet deposit too, and continue with the rest of the book. This will give you a chance to play around with Nimbus in a risk-free environment.

--- a/docs/the_nimbus_book/src/eth2-stats.md
+++ b/docs/the_nimbus_book/src/eth2-stats.md
@@ -1,5 +1,7 @@
 # Network stats and monitoring
 
+> ⚠️  This page concerns the Medalla testnet. If you have made a mainnet deposit, you do not need to connect to eth2 quite yet. Mainnet [Genesis](https://hackmd.io/@benjaminion/genesis) date has been set to [December 1st](https://blog.ethereum.org/2020/11/04/eth2-quick-update-no-19/). This page will be updated nearer the time.
+
 eth2stats is a network monitoring suite for your beacon node + validator client.
 
 It consists of a [command-line-interface](https://github.com/Alethio/eth2stats-client) (to help you query your node's API), and an [associated website](https://eth2stats.io/medalla-testnet)(which allows you to monitor your node from anywhere).

--- a/docs/the_nimbus_book/src/infura-guide.md
+++ b/docs/the_nimbus_book/src/infura-guide.md
@@ -1,5 +1,7 @@
 # Supplying your own Infura endpoint
 
+> ⚠️  This page concerns the Medalla testnet. If you have made a mainnet deposit, you do not need to connect to eth2 quite yet. Mainnet [Genesis](https://hackmd.io/@benjaminion/genesis) date has been set to [December 1st](https://blog.ethereum.org/2020/11/04/eth2-quick-update-no-19/). This page will be updated nearer the time.
+
 In a nutshell, Infura is a hosted ethereum node cluster that lets you make requests to the eth1 blockchain without requiring you to set up your own eth1 node.
 
 While we do support Infura to process incoming validator deposits, we recommend running your own eth1 node to avoid relying on a third-party-service.

--- a/docs/the_nimbus_book/src/intro.md
+++ b/docs/the_nimbus_book/src/intro.md
@@ -2,7 +2,10 @@
 
 The Nimbus beacon chain is a research implementation of the Beacon Chain – the core system level chain at the heart of Ethereum 2.0.
 
-This book strives to achieve two purposes: 1) to attempt to provide a more or less complete documentation of the Nimbus beacon chain, and 2) to explain the various ways in which you can use Nimbus to become a validator on eth2.
+This book strives to achieve two purposes:
+1. To attempt to provide a more or less complete **documentation of the Nimbus beacon chain**
+
+2. To explain the various ways in which you can **use Nimbus to become a validator on eth2**
 
 ### Helpful resources
 
@@ -16,10 +19,7 @@ This book strives to achieve two purposes: 1) to attempt to provide a more or le
 
 
 
-
 ## Introduction
-
-### What's the Beacon Chain?
 
 The beacon chain is the brain underpinning eth2 -- the next generation of Ethereum. It contains all of the machinery behind eth2's consensus.
 

--- a/docs/the_nimbus_book/src/keep-an-eye.md
+++ b/docs/the_nimbus_book/src/keep-an-eye.md
@@ -1,10 +1,19 @@
 # Keep an eye on your validator
  
- If you deposit after the [genesis](https://hackmd.io/@benjaminion/genesis) state was decided, your validator(s) will be put in a queue based on deposit time, and will slowly be inducted into the validator set after genesis. Getting through the queue may take a few hours or a day or so.
  
- The best way to keep track of your validator's status is [medalla.beaconcha.in](https:/medalla.beaconcha.in) (click on the orange magnifying glass at the very top and paste in your validator's public key).
+The best way to keep track of your validator's status is using the `beaconcha.in` explorer (click on the orange magnifying glass at the very top and paste in your validator's public key):
  
-You can even [create an account](https://medalla.beaconcha.in/register) to add alerts and keep track of your validator's [performance](https://medalla.beaconcha.in/dashboard).
+ - **Testnet:** [medalla.beaconcha.in](https:/medalla.beaconcha.in) 
+ - **Mainnet:** [beaconcha.in](https://beaconcha.in/)
+ 
+If you deposit after the [genesis](https://hackmd.io/@benjaminion/genesis) state was decided, your validator(s) will be put in a queue based on deposit time, and will slowly be inducted into the validator set after genesis. Getting through the queue may take a few hours or a day or so.
+
+ 
+You can even create an account ([testnet link](https://medalla.beaconcha.in/register), [mainnet link](https://beaconcha.in/register)) to add alerts and keep track of your validator's performance ([testnet link](https://medalla.beaconcha.in/dashboard), [mainnet link](https://beaconcha.in/dashboard)).
+
+-------------------------------
+
+> ⚠️  The rest of this page concerns the Medalla testnet only. If you have made a mainnet deposit, you do not need to run Nimbus quite yet. Mainnet [Genesis](https://hackmd.io/@benjaminion/genesis) date has been set to [December 1st](https://blog.ethereum.org/2020/11/04/eth2-quick-update-no-19/). This page will be updated nearer the time.
 
 ## Make sure your validator is attached
 

--- a/docs/the_nimbus_book/src/keep-updated.md
+++ b/docs/the_nimbus_book/src/keep-updated.md
@@ -1,12 +1,13 @@
-# Keep your validator updated
+# Keep Nimbus updated
 
 Make sure you stay on the lookout for any critical updates to Nimbus. This best way to do so is through the **announcements** channel on our [discord](https://discord.com/invite/XRxWahP).
 
-To update to the latest version, disconnect from medalla and run:
+To update to the latest version, run:
 
 ```
 git pull && make update
 ```
 
-Once the update is complete, run `make medalla` to reconnect to the network.
+> **Note:** If your beacon node is already running, you'll need to disconnect and reconnect for the changes to take effect.
+
 

--- a/docs/the_nimbus_book/src/keys.md
+++ b/docs/the_nimbus_book/src/keys.md
@@ -1,5 +1,10 @@
 # Manage your keys
 
+
+> ⚠️  This page concerns the Medalla testnet only. If you have made a mainnet deposit, you do not need to import your keys into Nimbus quite yet. 
+
+
+
 ## Import
 
 To import your signing key(s) into Nimbus, from the `nimbus-eth2` directory run:

--- a/docs/the_nimbus_book/src/metrics-pretty-pictures.md
+++ b/docs/the_nimbus_book/src/metrics-pretty-pictures.md
@@ -1,5 +1,7 @@
 # Metrics and pretty pictures
 
+> ⚠️  This page concerns the Medalla testnet. If you have made a mainnet deposit, you do not need to connect to eth2 quite yet. Mainnet [Genesis](https://hackmd.io/@benjaminion/genesis) date has been set to [December 1st](https://blog.ethereum.org/2020/11/04/eth2-quick-update-no-19/). This page will be updated nearer the time.
+
 In this page we'll cover how to use  Grafana and Prometheus to help you visualise important real-time metrics concerning your validator and/or beacon node.
 
 Prometheus is an open-source systems monitoring and alerting toolkit. It runs as a service on your computer and its job is to capture metrics. You can find more information about Prometheus [here](https://prometheus.io/docs/introduction/overview/).

--- a/docs/the_nimbus_book/src/pi-guide.md
+++ b/docs/the_nimbus_book/src/pi-guide.md
@@ -3,7 +3,7 @@
 <blockquote class="twitter-tweet"><p lang="en" dir="ltr">I expect the new Raspberry Pi 4 (4GB RAM option, external SSD) to handle an Eth2 validator node without breaking a sweat. That&#39;s $100 of hardware running at 10 Watts to support a 32 ETH node (currently ~$10K stake).</p>&mdash; Justin Ðrake (@drakefjustin) <a href="https://twitter.com/drakefjustin/status/1143091047058366465?ref_src=twsrc%5Etfw">June 24, 2019</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
 ## Introduction
-This page will take you through how to use your laptop to program your Raspberry Pi, get Nimbus running, and connect to the Medalla testnet (if this is not something you plan on doing, feel free to [skip ahead](./keep-an-eye.md)).
+This page will take you through how to use your laptop to program your Raspberry Pi, get Nimbus running, and connect to the **Medalla testnet** (if this is not something you plan on doing, feel free to [skip ahead](./keep-an-eye.md)).
 
 One of the most important aspects of the Raspberry Pi experience is trying to make it as easy as possible to get started. As such, we try our best to explain things from first-principles.
 

--- a/docs/the_nimbus_book/src/start-syncing.md
+++ b/docs/the_nimbus_book/src/start-syncing.md
@@ -1,8 +1,12 @@
+
 # Start syncing
 
-To avoid being hit with minor penalties, the beacon node should be [completely synced](./keep-an-eye.md#keep-track-of-your-syncing-progress) before submitting your deposit.
+> **Note:** If you're planning on making a mainnet [deposit](./deposit.md) you can safely skip this step.
+
+If you're joining a network that has already launched, you need to ensure that your beacon node is [completely synced](./keep-an-eye.md#keep-track-of-your-syncing-progress) before submitting your deposit.
 
 This is particularly important if you are joining a network that's been running for a while.
+
 
 To start syncing `medalla` , from the `nimbus-eth2` repository, run:
 
@@ -10,7 +14,6 @@ To start syncing `medalla` , from the `nimbus-eth2` repository, run:
 make medalla
 ```
 
-> **Note:** If you planning on [making a deposit](./deposit.md) before the network you'd like to join has launched -- whether mainnet or a testnet -- you can safely skip this step.
 
 
 

--- a/docs/the_nimbus_book/src/troubleshooting.md
+++ b/docs/the_nimbus_book/src/troubleshooting.md
@@ -1,4 +1,7 @@
-# Troubleshooting (Medalla)
+# Troubleshooting
+
+> ⚠️  This page concerns the Medalla testnet. If you have made a mainnet deposit, you do not need to connect to eth2 quite yet. Mainnet [Genesis](https://hackmd.io/@benjaminion/genesis) date has been set to [December 1st](https://blog.ethereum.org/2020/11/04/eth2-quick-update-no-19/). This page will be updated nearer the time.
+
 
 As it stands, we are continuously making improvements to both stability and memory usage. So please make sure you keep your client up to date! This means restarting your node and updating your software regularly from the `master` branch. If you can't find a solution to your problem here, feel free to hit us up on our [discord](https://discord.com/invite/XRxWahP)!
 
@@ -57,10 +60,6 @@ If you're experiencing a low peer count, you may be behind a firewall. Try resta
 make NODE_PARAMS="--nat:\"extip:35.124.65.104\"" medalla
 ```
 
-### Resource leaks
-
-If you're experiencing RAM related resource leaks, try restarting your client (**we recommend restarting every 6 hours** until we get to the bottom of this issue). If you have a [local Grafana setup](https://github.com/status-im/nimbus-eth2#getting-metrics-from-a-local-testnet-client), you can try monitoring the severity of these leaks and playing around with the restart interval.
-
 ### Address already in use error
 
 If you're seeing an error that looks like:
@@ -79,12 +78,12 @@ make BASE_PORT=9100 medalla
 
 (You can replace `9100` with a port of your choosing)
 
-### Mainchain monitor failure
+### Eth1 chain monitor failure
 
 If you're seeing one or more error messages that look like the following:
 
 ```
-ERR 2020-09-29 14:04:33.313+02:00 Mainchain monitor failure, restarting      tid=8941404 
+ERR 2020-09-29 14:04:33.313+02:00 Eth1 chain monitor failure, restarting      tid=8941404 
 file=eth1_monitor.nim:812 err="{\"code\":-32005,
 \"data\":{\"rate\":{\"allowed_rps\":1,
 \"backoff_seconds\":24,
@@ -95,7 +94,7 @@ file=eth1_monitor.nim:812 err="{\"code\":-32005,
 
 This means that our Infura endpoint is overloaded (in other words, the requests on a given day have reached the 100k free tier limit). 
 
-You can fix this by passing in your own Infura endpoint.
+You can fix this by passing in [your own Infura endpoint](./infura-guide.md).
 
 To do so, run: 
 


### PR DESCRIPTION
Main changes:

- update deposit page (confirm mainnet deposit contract)
- add warnings to pages that apply only to testnets
- remove outdated section from troubleshooting
- miscellaneous edits