### PR TITLE
keep AllTests-mainnet.md consistent; don't send overly large messages

### DIFF
--- a/beacon_chain.nimble
+++ b/beacon_chain.nimble
@@ -87,8 +87,8 @@ task test, "Run all tests":
   buildAndRunBinary "test_process_attestation", "tests/spec_block_processing/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v0.12.3" -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
   buildAndRunBinary "test_process_deposits", "tests/spec_block_processing/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v0.12.3" -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
   buildAndRunBinary "all_fixtures_require_ssz", "tests/official/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v0.12.3" -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
-  buildAndRunBinary "test_attestation_pool", "tests/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v0.12.3" -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
-  buildAndRunBinary "test_block_pool", "tests/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v0.12.3" -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "test_attestation_pool", "tests/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v1.0.0" -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "test_block_pool", "tests/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v1.0.0" -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
 
   # State and block sims; getting to 4th epoch triggers consensus checks
   buildAndRunBinary "state_sim", "research/", "-d:const_preset=mainnet -d:ETH2_SPEC=\"v1.0.0\" -d:chronicles_log_level=INFO", "--validators=3000 --slots=128"

--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -1470,8 +1470,12 @@ proc traceMessage(fut: FutureBase, msgId: string) =
       debug "Unexpected future state for gossip", msgId, state = fut.state
 
 proc broadcast*(node: Eth2Node, topic: string, msg: auto) =
+  let data = snappy.encode(SSZ.encode(msg))
+
+  # This is only for messages we create. A message this large amounts to an
+  # internal logic error.
+  doAssert data.len <= GOSSIP_MAX_SIZE
   inc nbc_gossip_messages_sent
-  let
-    data = snappy.encode(SSZ.encode(msg))
+
   var futSnappy = node.pubsub.publish(topic & "_snappy", data)
   traceMessage(futSnappy, string.fromBytes(gossipId(data)))


### PR DESCRIPTION
https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/p2p-interface.md#topics-and-messages suggests that it's the (Snappy) encoded size which is bounded at `GOSSIP_MAX_SIZE`.