### PR TITLE
Use separate cache for getting epochref

### DIFF
--- a/beacon_chain/block_pools/block_pools_types.nim
+++ b/beacon_chain/block_pools/block_pools_types.nim
@@ -110,10 +110,6 @@ type
     heads*: seq[BlockRef] ##\
     ## Candidate heads of candidate chains
 
-    head*: BlockRef ##\
-    ## The latest block we know about, that's been chosen as a head by the fork
-    ## choice rule
-
     finalizedHead*: BlockSlot ##\
     ## The latest block that was finalized according to the block in head
     ## Ancestors of this block are guaranteed to have 1 child only.
@@ -122,14 +118,18 @@ type
     # Rewinder - Mutable state processing
 
     headState*: StateData ##\
-    ## State given by the head block; only update in `updateHead`, not anywhere
-    ## else via `withState`
+    ## State given by the head block - must only be updated in `updateHead` -
+    ## always matches dag.head
 
-    tmpState*: StateData ## Scratchpad - may be any state
+    epochRefState*: StateData ##\
+      ## State used to produce epochRef instances - must only be used in
+      ## `getEpochRef`
 
     clearanceState*: StateData ##\
-      ## Cached state used during block clearance - should only be used in the
-      ## clearance module to avoid the risk of modifying it in a callback
+      ## Cached state used during block clearance - must only be used in
+      ## clearance module
+
+    tmpState*: StateData ## Scratchpad - may be any state
 
     updateFlags*: UpdateFlags
 
@@ -201,6 +201,8 @@ type
     epochRef: EpochRef, state: HashedBeaconState) {.raises: [Defect], gcsafe.}
 
 template validator_keys*(e: EpochRef): untyped = e.validator_key_store[1][]
+
+template head*(v: ChainDagRef): BlockRef = v.headState.blck
 
 func shortLog*(v: BlockSlot): string =
   if v.blck.slot == v.slot:

--- a/beacon_chain/block_pools/chain_dag.nim
+++ b/beacon_chain/block_pools/chain_dag.nim
@@ -389,13 +389,13 @@ proc init*(T: type ChainDAGRef,
   let res = ChainDAGRef(
     blocks: blocks,
     tail: tailRef,
-    head: headRef,
     genesis: genesisRef,
     db: db,
     heads: @[headRef],
     headState: tmpState[],
-    tmpState: tmpState[],
+    epochRefState: tmpState[],
     clearanceState: tmpState[],
+    tmpState: tmpState[],
 
     # The only allowed flag right now is verifyFinalization, as the others all
     # allow skipping some validation.
@@ -446,7 +446,7 @@ proc getEpochRef*(dag: ChainDAGRef, blck: BlockRef, epoch: Epoch): EpochRef =
   let
     ancestor = blck.epochAncestor(epoch)
 
-  dag.withState(dag.tmpState, ancestor):
+  dag.withState(dag.epochRefState, ancestor):
     let
       prevEpochRef = if dag.tail.slot.epoch >= epoch: nil
                      else: blck.findEpochRef(epoch - 1)
@@ -702,6 +702,11 @@ proc updateStateData*(
       found = true
       break
 
+    if canAdvance(dag.epochRefState, cur):
+      assign(state, dag.epochRefState)
+      found = true
+      break
+
     if cur.slot == cur.blck.slot:
       # This is not an empty slot, so the block will need to be applied to
       # eventually reach bs
@@ -811,8 +816,6 @@ proc updateHead*(
   var cache: StateCache
   updateStateData(
     dag, dag.headState, newHead.atSlot(newHead.slot), false, cache)
-
-  dag.head = newHead
 
   if not lastHead.isAncestorOf(newHead):
     notice "Updated head block with chain reorg",


### PR DESCRIPTION
...else tmpState gets overwritten when producing blocks and requesting
epochRef for finalized state.