### PR TITLE
remove v0.12.3 EF test vectors to save 2.7GB of space in CI instances

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -105,7 +105,7 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + CHURN_LIMIT_QUOTIENT                              65536                [Preset: mainnet]   OK
   CONFIG_NAME                                       "mainnet"            [Preset: mainnet]   Skip
   DEPOSIT_CHAIN_ID                                  1                    [Preset: mainnet]   Skip
-  DEPOSIT_CONTRACT_ADDRESS                          "0x1234567890123456789012345678901234567 Skip
+  DEPOSIT_CONTRACT_ADDRESS                          "0x00000000219ab540356cBB839Cbe05303d770 Skip
   DEPOSIT_NETWORK_ID                                1                    [Preset: mainnet]   Skip
 + DOMAIN_AGGREGATE_AND_PROOF                        "0x06000000"         [Preset: mainnet]   OK
 + DOMAIN_BEACON_ATTESTER                            "0x01000000"         [Preset: mainnet]   OK
@@ -116,18 +116,18 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + DOMAIN_VOLUNTARY_EXIT                             "0x04000000"         [Preset: mainnet]   OK
 + EFFECTIVE_BALANCE_INCREMENT                       1000000000           [Preset: mainnet]   OK
 + EJECTION_BALANCE                                  16000000000          [Preset: mainnet]   OK
-+ EPOCHS_PER_ETH1_VOTING_PERIOD                     32                   [Preset: mainnet]   OK
++ EPOCHS_PER_ETH1_VOTING_PERIOD                     64                   [Preset: mainnet]   OK
 + EPOCHS_PER_HISTORICAL_VECTOR                      65536                [Preset: mainnet]   OK
 + EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION             256                  [Preset: mainnet]   OK
 + EPOCHS_PER_SLASHINGS_VECTOR                       8192                 [Preset: mainnet]   OK
-  ETH1_FOLLOW_DISTANCE                              1024                 [Preset: mainnet]   Skip
-  GENESIS_DELAY                                     172800               [Preset: mainnet]   Skip
+  ETH1_FOLLOW_DISTANCE                              2048                 [Preset: mainnet]   Skip
+  GENESIS_DELAY                                     604800               [Preset: mainnet]   Skip
   GENESIS_FORK_VERSION                              "0x00000000"         [Preset: mainnet]   Skip
 + HISTORICAL_ROOTS_LIMIT                            16777216             [Preset: mainnet]   OK
 + HYSTERESIS_DOWNWARD_MULTIPLIER                    1                    [Preset: mainnet]   OK
 + HYSTERESIS_QUOTIENT                               4                    [Preset: mainnet]   OK
 + HYSTERESIS_UPWARD_MULTIPLIER                      5                    [Preset: mainnet]   OK
-+ INACTIVITY_PENALTY_QUOTIENT                       16777216             [Preset: mainnet]   OK
++ INACTIVITY_PENALTY_QUOTIENT                       67108864             [Preset: mainnet]   OK
 + MAX_ATTESTATIONS                                  128                  [Preset: mainnet]   OK
 + MAX_ATTESTER_SLASHINGS                            2                    [Preset: mainnet]   OK
 + MAX_COMMITTEES_PER_SLOT                           64                   [Preset: mainnet]   OK
@@ -141,12 +141,12 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + MIN_DEPOSIT_AMOUNT                                1000000000           [Preset: mainnet]   OK
 + MIN_EPOCHS_TO_INACTIVITY_PENALTY                  4                    [Preset: mainnet]   OK
   MIN_GENESIS_ACTIVE_VALIDATOR_COUNT                16384                [Preset: mainnet]   Skip
-  MIN_GENESIS_TIME                                  1578009600           [Preset: mainnet]   Skip
+  MIN_GENESIS_TIME                                  1606824000           [Preset: mainnet]   Skip
 + MIN_PER_EPOCH_CHURN_LIMIT                         4                    [Preset: mainnet]   OK
 + MIN_SEED_LOOKAHEAD                                1                    [Preset: mainnet]   OK
-+ MIN_SLASHING_PENALTY_QUOTIENT                     32                   [Preset: mainnet]   OK
++ MIN_SLASHING_PENALTY_QUOTIENT                     128                  [Preset: mainnet]   OK
 + MIN_VALIDATOR_WITHDRAWABILITY_DELAY               256                  [Preset: mainnet]   OK
-+ PROPORTIONAL_SLASHING_MULTIPLIER                  3                    [Preset: mainnet]   OK
++ PROPORTIONAL_SLASHING_MULTIPLIER                  1                    [Preset: mainnet]   OK
 + PROPOSER_REWARD_QUOTIENT                          8                    [Preset: mainnet]   OK
 + RANDOM_SUBNETS_PER_VALIDATOR                      1                    [Preset: mainnet]   OK
 + SAFE_SLOTS_TO_UPDATE_JUSTIFIED                    8                    [Preset: mainnet]   OK

--- a/FixtureAll-mainnet.md
+++ b/FixtureAll-mainnet.md
@@ -68,12 +68,13 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + [Invalid] too_few_aggregation_bits                                                         OK
 + [Invalid] too_many_aggregation_bits                                                        OK
 + [Invalid] wrong_index_for_committee_signature                                              OK
-+ [Invalid] wrong_index_for_slot                                                             OK
++ [Invalid] wrong_index_for_slot_0                                                           OK
++ [Invalid] wrong_index_for_slot_1                                                           OK
 + [Valid]   success                                                                          OK
 + [Valid]   success_multi_proposer_index_iterations                                          OK
 + [Valid]   success_previous_epoch                                                           OK
 ```
-OK: 21/21 Fail: 0/21 Skip: 0/21
+OK: 22/22 Fail: 0/22 Skip: 0/22
 ## Official - Operations - Attester slashing  [Preset: mainnet]
 ```diff
 + [Invalid] all_empty_indices                                                                OK
@@ -222,6 +223,7 @@ OK: 44/44 Fail: 0/44 Skip: 0/44
 + [Invalid] Official - Sanity - Blocks - prev_slot_block_transition [Preset: mainnet]        OK
 + [Invalid] Official - Sanity - Blocks - proposal_for_genesis_slot [Preset: mainnet]         OK
 + [Invalid] Official - Sanity - Blocks - same_slot_block_transition [Preset: mainnet]        OK
++ [Invalid] Official - Sanity - Blocks - slash_and_exit_same_index [Preset: mainnet]         OK
 + [Invalid] Official - Sanity - Blocks - zero_block_sig [Preset: mainnet]                    OK
 + [Valid]   Official - Sanity - Blocks - attestation [Preset: mainnet]                       OK
 + [Valid]   Official - Sanity - Blocks - attester_slashing [Preset: mainnet]                 OK
@@ -230,6 +232,10 @@ OK: 44/44 Fail: 0/44 Skip: 0/44
 + [Valid]   Official - Sanity - Blocks - deposit_top_up [Preset: mainnet]                    OK
 + [Valid]   Official - Sanity - Blocks - empty_block_transition [Preset: mainnet]            OK
 + [Valid]   Official - Sanity - Blocks - empty_epoch_transition [Preset: mainnet]            OK
++ [Valid]   Official - Sanity - Blocks - full_random_operations_0 [Preset: mainnet]          OK
++ [Valid]   Official - Sanity - Blocks - full_random_operations_1 [Preset: mainnet]          OK
++ [Valid]   Official - Sanity - Blocks - full_random_operations_2 [Preset: mainnet]          OK
++ [Valid]   Official - Sanity - Blocks - full_random_operations_3 [Preset: mainnet]          OK
 + [Valid]   Official - Sanity - Blocks - high_proposer_index [Preset: mainnet]               OK
 + [Valid]   Official - Sanity - Blocks - historical_batch [Preset: mainnet]                  OK
 + [Valid]   Official - Sanity - Blocks - multiple_attester_slashings_no_overlap [Preset: mai OK
@@ -240,9 +246,10 @@ OK: 44/44 Fail: 0/44 Skip: 0/44
 + [Valid]   Official - Sanity - Blocks - proposer_self_slashing [Preset: mainnet]            OK
 + [Valid]   Official - Sanity - Blocks - proposer_slashing [Preset: mainnet]                 OK
 + [Valid]   Official - Sanity - Blocks - skipped_slots [Preset: mainnet]                     OK
++ [Valid]   Official - Sanity - Blocks - slash_and_exit_diff_index [Preset: mainnet]         OK
 + [Valid]   Official - Sanity - Blocks - voluntary_exit [Preset: mainnet]                    OK
 ```
-OK: 32/32 Fail: 0/32 Skip: 0/32
+OK: 38/38 Fail: 0/38 Skip: 0/38
 ## Official - Sanity - Slots  [Preset: mainnet]
 ```diff
 + Slots - double_empty_epoch                                                                 OK
@@ -254,4 +261,4 @@ OK: 32/32 Fail: 0/32 Skip: 0/32
 OK: 5/5 Fail: 0/5 Skip: 0/5
 
 ---TOTAL---
-OK: 196/196 Fail: 0/196 Skip: 0/196
+OK: 203/203 Fail: 0/203 Skip: 0/203

--- a/beacon_chain.nimble
+++ b/beacon_chain.nimble
@@ -61,34 +61,32 @@ task test, "Run all tests":
   # pieces of code get tested regularly. Increased test output verbosity is the
   # price we pay for that.
 
-  # TODO re-add minimal const sanity check for 1.0.0
+  buildAndRunBinary "test_fixture_const_sanity_check", "tests/official/", """-d:const_preset=minimal -d:ETH2_SPEC="v1.0.0" -d:chronicles_sinks="json[file]""""
   buildAndRunBinary "test_fixture_const_sanity_check", "tests/official/", """-d:const_preset=mainnet -d:ETH2_SPEC="v1.0.0" -d:chronicles_sinks="json[file]""""
 
   # Generic SSZ test, doesn't use consensus objects minimal/mainnet presets
   buildAndRunBinary "test_fixture_ssz_generic_types", "tests/official/", """-d:ETH2_SPEC="v1.0.0" -d:chronicles_log_level=TRACE -d:chronicles_sinks="json[file]""""
 
   # Consensus object SSZ tests
-  # v0.12.3 is reasonably covered by rest of SSZ fixture tests and lack of
-  # non-numeric-constant changes in SSZ types between v0.12.3 and v1.0.0.
   buildAndRunBinary "test_fixture_ssz_consensus_objects", "tests/official/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v1.0.0" -d:chronicles_sinks="json[file]""""
 
   # EF tests
   buildAndRunBinary "all_fixtures_require_ssz", "tests/official/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v1.0.0" -d:chronicles_sinks="json[file]""""
 
   # Mainnet config
-  buildAndRunBinary "proto_array", "beacon_chain/fork_choice/", """-d:const_preset=mainnet -d:ETH2_SPEC="v0.12.3" -d:chronicles_sinks="json[file]""""
-  buildAndRunBinary "fork_choice", "beacon_chain/fork_choice/", """-d:const_preset=mainnet -d:ETH2_SPEC="v0.12.3" -d:chronicles_sinks="json[file]""""
-  buildAndRunBinary "all_tests", "tests/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v0.12.3" -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "proto_array", "beacon_chain/fork_choice/", """-d:const_preset=mainnet -d:ETH2_SPEC="v1.0.0" -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "fork_choice", "beacon_chain/fork_choice/", """-d:const_preset=mainnet -d:ETH2_SPEC="v1.0.0" -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "all_tests", "tests/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v1.0.0" -d:chronicles_sinks="json[file]""""
   # TODO `test_keystore` is extracted from the rest of the tests because it uses conflicting BLST headers
-  buildAndRunBinary "test_keystore", "tests/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v0.12.3" -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "test_keystore", "tests/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v1.0.0" -d:chronicles_sinks="json[file]""""
 
   # Check Miracl/Milagro fallback on select tests
-  buildAndRunBinary "test_interop", "tests/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v0.12.3" -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "test_interop", "tests/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v1.0.0" -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
   buildAndRunBinary "test_process_attestation", "tests/spec_block_processing/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v0.12.3" -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
   buildAndRunBinary "test_process_deposits", "tests/spec_block_processing/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v0.12.3" -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
-  buildAndRunBinary "all_fixtures_require_ssz", "tests/official/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v0.12.3" -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
-  buildAndRunBinary "test_attestation_pool", "tests/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v1.0.0" -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
-  buildAndRunBinary "test_block_pool", "tests/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v1.0.0" -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "all_fixtures_require_ssz", "tests/official/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v1.0.0" -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "test_attestation_pool", "tests/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v0.12.3" -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "test_block_pool", "tests/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC="v0.12.3" -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
 
   # State and block sims; getting to 4th epoch triggers consensus checks
   buildAndRunBinary "state_sim", "research/", "-d:const_preset=mainnet -d:ETH2_SPEC=\"v1.0.0\" -d:chronicles_log_level=INFO", "--validators=3000 --slots=128"

--- a/tests/official/test_fixture_state_transition_epoch.nim
+++ b/tests/official/test_fixture_state_transition_epoch.nim
@@ -29,6 +29,7 @@ template runSuite(suiteDir, testName: string, transitionProc: untyped{ident}, us
 
   proc `suiteImpl _ transitionProc`() =
     suiteReport "Official - Epoch Processing - " & testName & preset():
+      doAssert dirExists(suiteDir)
       for testDir in walkDirRec(suiteDir, yieldFilter = {pcDir}):
 
         let unitTestName = testDir.rsplit(DirSep, 1)[1]


### PR DESCRIPTION
GitHub Actions Windows 64-bit CI's been failing all day with disk full errors.

The v0.12.3 test vectors were going to disappear soon enough. Just don't modify the v0.12.3 const presets for their limited remaining lifetime and it'll be fine.