### PR TITLE
add rpc call to get chronos futures at runtime

### DIFF
--- a/docs/the_nimbus_book/src/api.md
+++ b/docs/the_nimbus_book/src/api.md
@@ -183,3 +183,11 @@ Set the current logging level dynamically: TRACE, DEBUG, INFO, NOTICE, WARN, ERR
 ```
 curl -d '{"jsonrpc":"2.0","id":"id","method":"setLogLevel","params":["DEBUG; TRACE:discv5,libp2p; REQUIRED:none; DISABLED:none"] }' -H 'Content-Type: application/json' localhost:9190 -s | jq
 ```
+
+### getChronosFutures
+
+Get the current list of live async futures in the process - compile with `-d:chronosFutureTracking` to enable.
+
+```
+curl -d '{"jsonrpc":"2.0","id":"id","method":"getChronosFutures","params":[] }' -H 'Content-Type: application/json' localhost:9190 -s | jq '.result | (.[0] | keys_unsorted) as $keys | $keys, map([.[ $keys[] ]])[] | @csv'
+```


### PR DESCRIPTION
```
[arnetheduck@tempus nim-libp2p]$ curl -d '{"jsonrpc":"2.0","id":"id","method":"getChronosFutures","params":[] }' -H 'Content-Type: application/json' localhost:9190 -s | jq '.result | (.[0] | keys_unsorted) as $keys | $keys, map([.[ $keys[] ]])[] | @csv'
"\"id\",\"procname\",\"filename\",\"line\",\"state\""
"1,\"stream.transport.server\",\"stream.nim\",1826,\"Pending\""
"2,\"statusBarUpdatesPollingLoop\",\"nimbus_beacon_node.nim\",984,\"Pending\""
"6,\"datagram.transport\",\"datagram.nim\",571,\"Pending\""
"10,\"stream.transport.server\",\"stream.nim\",1826,\"Pending\""
"11,\"stream.transport.server.join\",\"stream.nim\",1610,\"Pending\""
"13,\"heartbeat\",\"gossipsub.nim\",751,\"Pending\""
"15,\"maintainDirectPeers\",\"gossipsub.nim\",1289,\"Pending\""
"16,\"chronos.sleepAsync(Duration)\",\"asyncloop.nim\",788,\"Pending\""
...
```
