### PR TITLE
hotfix fork choice score application

### DIFF
--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -178,7 +178,7 @@ func apply_score_changes*(
         #
         # with 5 the canonical chain and 6 a discarded fork
         # that will be pruned next.
-        break
+        continue
 
       if parent_physical_index >= deltas.len:
         return err ForkChoiceError(


### PR DESCRIPTION
Depending on the order of nodes in fork choice, it seems that the break
here could cause some scores not to be applied correctly