### PR TITLE
Add a record create and print command

### DIFF
--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -1236,7 +1236,7 @@ template tcpEndPoint(address, port): auto =
 proc getPersistentNetKeys*(rng: var BrHmacDrbgContext,
                            conf: BeaconNodeConf): KeyPair =
   case conf.cmd
-  of noCommand:
+  of noCommand, record:
     if conf.netKeyFile == "random":
       let res = PrivateKey.random(Secp256k1, rng)
       if res.isErr():

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1315,3 +1315,30 @@ programMain:
 
     of WalletsCmd.restore:
       restoreWalletInteractively(rng[], config)
+
+  of record:
+    case config.recordCmd:
+    of RecordCmd.create:
+      let netKeys = getPersistentNetKeys(rng[], config)
+
+      var fieldPairs: seq[FieldPair]
+      for field in config.fields:
+        let fieldPair = field.split(":")
+        if fieldPair.len > 1:
+          fieldPairs.add(toFieldPair(fieldPair[0], hexToSeqByte(fieldPair[1])))
+        else:
+          fatal "Invalid field pair"
+          quit QuitFailure
+
+      let record = enr.Record.init(
+        config.seqNumber,
+        netKeys.seckey.asEthKey,
+        some(config.ipExt),
+        config.tcpPortExt,
+        config.udpPortExt,
+        fieldPairs).expect("Record within size limits")
+
+      echo record.toURI()
+
+    of RecordCmd.print:
+      echo $config.recordPrint


### PR DESCRIPTION
Allows for offline ENR creation.
Tested for pyrmont with 
`./build/nimbus_beacon_node record create --ip:<external ip address> --tcp-port:9000 --udp-port:9000 --netkey-file:./netkey --insecure-netkey-password:true --field:eth2:0x3B08879500002009FFFFFFFFFFFFFFFF --field:attnets:0xFFFFFFFFFFFFFFFF`

And then using that netkey in a run. Gave the same ENR.