### PR TITLE
Implement means for posting validator exits

### DIFF
--- a/beacon_chain/eth2_json_rpc_serialization.nim
+++ b/beacon_chain/eth2_json_rpc_serialization.nim
@@ -48,9 +48,19 @@ template genFromJsonForIntType(T: untyped) =
   proc fromJson*(n: JsonNode, argName: string, result: var T) =
     n.kind.expect(JInt, argName)
     let asInt = n.getBiggestInt()
-    # signed -> unsigned conversions are unchecked
-    # https://github.com/nim-lang/RFCs/issues/175
+    when T is Epoch:
+      if asInt == -1:
+        # TODO: This is a major hack here. Since the json library
+        # cannot handle properly 0xffffffff when serializing and
+        # deserializing uint64 values, we detect one known wrong
+        # result, appering in most `Validator` records. To fix
+        # this issue, we'll have to switch to nim-json-serialization
+        # in nim-json-rpc or work towards implementing a fix upstream.
+        result = FAR_FUTURE_EPOCH
+        return
     if asInt < 0:
+      # signed -> unsigned conversions are unchecked
+      # https://github.com/nim-lang/RFCs/issues/175
       raise newException(
         ValueError, "JSON-RPC input is an unexpected negative value")
     result = T(asInt)

--- a/beacon_chain/exit_pool.nim
+++ b/beacon_chain/exit_pool.nim
@@ -213,7 +213,7 @@ proc validateProposerSlashing*(
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/p2p-interface.md#voluntary_exit
 proc validateVoluntaryExit*(
     pool: var ExitPool, signed_voluntary_exit: SignedVoluntaryExit):
-    Result[bool, (ValidationResult, cstring)] =
+    Result[void, (ValidationResult, cstring)] =
   # [IGNORE] The voluntary exit is the first valid voluntary exit received for
   # the validator with index signed_voluntary_exit.message.validator_index.
   if signed_voluntary_exit.message.validator_index >=
@@ -241,4 +241,4 @@ proc validateVoluntaryExit*(
   pool.voluntary_exits.addExitMessage(
     signed_voluntary_exit, VOLUNTARY_EXITS_BOUND)
 
-  ok(true)
+  ok()

--- a/beacon_chain/keystore_management.nim
+++ b/beacon_chain/keystore_management.nim
@@ -38,7 +38,7 @@ const
       "../vendor/nimbus-security-resources/passwords/10-million-password-list-top-100000.txt",
     minWordLen = minPasswordLen)
 
-proc echoP(msg: string) =
+proc echoP*(msg: string) =
   ## Prints a paragraph aligned to 80 columns
   echo ""
   echo wrapWords(msg, 80)
@@ -213,8 +213,8 @@ proc keyboardGetPassword[T](prompt: string, attempts: int,
       dec(remainingAttempts)
   err("Failed to decrypt keystore")
 
-proc loadKeystore(validatorsDir, secretsDir, keyName: string,
-                  nonInteractive: bool): Option[ValidatorPrivKey] =
+proc loadKeystore*(validatorsDir, secretsDir, keyName: string,
+                   nonInteractive: bool): Option[ValidatorPrivKey] =
   let
     keystorePath = validatorsDir / keyName / keystoreFileName
     keystore =

--- a/beacon_chain/network_metadata.nim
+++ b/beacon_chain/network_metadata.nim
@@ -4,10 +4,10 @@ import
   eth/common/eth_types as commonEthTypes,
   web3/[ethtypes, conversions],
   chronicles,
-  spec/presets,
-  spec/datatypes,
   json_serialization,
-  json_serialization/std/[options, sets, net], serialization/errors
+  json_serialization/std/[options, sets, net], serialization/errors,
+  ssz/navigator,
+  spec/[presets, datatypes, digest]
 
 # ATTENTION! This file will produce a large C file, because we are inlining
 # genesis states as C literals in the generated code (and blobs in the final
@@ -219,3 +219,7 @@ proc getRuntimePresetForNetwork*(eth2Network: Option[string]): RuntimePreset =
   if eth2Network.isSome:
     return getMetadataForNetwork(eth2Network.get).runtimePreset
   return defaultRuntimePreset
+
+proc extractGenesisValidatorRootFromSnapshop*(snapshot: string): Eth2Digest =
+  sszMount(snapshot, BeaconState).genesis_validators_root[]
+

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1120,16 +1120,16 @@ proc handleValidatorExitCommand(config: BeaconNodeConf) {.async.} =
 
     echoP "By requesting an exit now, you'll be exempt from penalties " &
           "stemming from not performing your validator duties, but you " &
-          "won't be able to withdraw your deposited funds at the time " &
+          "won't be able to withdraw your deposited funds for the time " &
           "being. This means that your funds will be effectively frozen " &
-          "until withdrawals are enabled in a future phase of the Eth2 " &
-          "rollout."
+          "until withdrawals are enabled in a future phase of Eth2."
+          
 
     echoP "To understand more about the Eth2 roadmap, we recommend you " &
           "have a look at\n" &
           "https://ethereum.org/en/eth2/#roadmap"
 
-    echoP "You must not shut down your validator for at least 5 epochs " &
+    echoP "You must keep your validator running for at least 5 epochs " &
           "(32 minutes) after requesting a validator exit, as you will " &
           "still be required to perform validator duties until your exit " &
           "has been processed. The number of epochs could be significantly " &

--- a/beacon_chain/spec/eth2_apis/beacon_callsigs.nim
+++ b/beacon_chain/spec/eth2_apis/beacon_callsigs.nim
@@ -54,8 +54,8 @@ proc get_v1_beacon_blocks_blockId_attestations(blockId: string): seq[Attestation
 # TODO GET  /v1/beacon/pool/attestations
 
 
-
 proc post_v1_beacon_pool_attestations(attestation: Attestation): bool
+proc post_v1_beacon_pool_voluntary_exits(exit: SignedVoluntaryExit): bool
 
 proc get_v1_config_fork_schedule(): seq[Fork]
 

--- a/beacon_chain/spec/eth2_apis/beacon_rpc_client.nim
+++ b/beacon_chain/spec/eth2_apis/beacon_rpc_client.nim
@@ -1,0 +1,9 @@
+import
+  os, json,
+  json_rpc/[rpcclient, jsonmarshal],
+  ../../eth2_json_rpc_serialization,
+  ../digest, ../datatypes,
+  callsigs_types
+
+createRpcSigs(RpcClient, currentSourcePath.parentDir / "beacon_callsigs.nim")
+

--- a/beacon_chain/spec/eth2_apis/callsigs_types.nim
+++ b/beacon_chain/spec/eth2_apis/callsigs_types.nim
@@ -30,6 +30,7 @@ type
 
   BeaconStatesValidatorsTuple* = tuple
     validator: Validator
+    index: uint64
     status: string
     balance: uint64
 

--- a/beacon_chain/spec/signatures.nim
+++ b/beacon_chain/spec/signatures.nim
@@ -178,10 +178,24 @@ proc verify_deposit_signature*(preset: RuntimePreset,
 
   blsVerify(deposit.pubkey, signing_root.data, deposit.signature)
 
-proc verify_voluntary_exit_signature*(
-    fork: Fork, genesis_validators_root: Eth2Digest,
+func get_voluntary_exit_signature*(
+    fork: Fork,
+    genesis_validators_root: Eth2Digest,
     voluntary_exit: VoluntaryExit,
-    pubkey: ValidatorPubKey, signature: SomeSig): bool =
+    privkey: ValidatorPrivKey): ValidatorSig =
+  let
+    domain = get_domain(
+      fork, DOMAIN_VOLUNTARY_EXIT, voluntary_exit.epoch, genesis_validators_root)
+    signing_root = compute_signing_root(voluntary_exit, domain)
+
+  blsSign(privKey, signing_root.data)
+
+proc verify_voluntary_exit_signature*(
+    fork: Fork,
+    genesis_validators_root: Eth2Digest,
+    voluntary_exit: VoluntaryExit,
+    pubkey: ValidatorPubKey,
+    signature: SomeSig): bool =
   withTrust(signature):
     let
       domain = get_domain(

--- a/beacon_chain/validator_duties.nim
+++ b/beacon_chain/validator_duties.nim
@@ -157,6 +157,11 @@ proc sendAttestation*(
 
   beacon_attestations_sent.inc()
 
+proc sendVoluntaryExit*(node: BeaconNode, exit: SignedVoluntaryExit) =
+  node.network.broadcast(
+    getVoluntaryExitsTopic(node.forkDIgest),
+    exit)
+
 proc sendAttestation*(node: BeaconNode, attestation: Attestation) =
   # For the validator API, which doesn't supply num_active_validators.
   let attestationBlck =


### PR DESCRIPTION
Remaining items:

* [ ] Implement a CLI command from producing a `SignedValidatorExit` message in JSON form.
* [ ] Add a script that creates a signed message and then posts it with `curl` against a running node