### PR TITLE
reduce peak memory usage during build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,8 +273,7 @@ jobs:
         shell: bash
         working-directory: nim-beacon-chain
         run: |
-          make -j$ncpu ARCH_OVERRIDE=$PLATFORM LOG_LEVEL=TRACE NIMFLAGS="-d:testnet_servers_image" nimbus_beacon_node
-          make -j$ncpu ARCH_OVERRIDE=$PLATFORM LOG_LEVEL=TRACE NIMFLAGS="-d:testnet_servers_image" nimbus_validator_client
+          make -j$ncpu ARCH_OVERRIDE=$PLATFORM LOG_LEVEL=TRACE NIMFLAGS="-d:testnet_servers_image" nimbus_beacon_node nimbus_validator_client
 
       - name: Run nim-beacon-chain tests
         if: matrix.target.TEST_KIND == 'unit-tests'
@@ -288,11 +287,11 @@ jobs:
         shell: bash
         working-directory: nim-beacon-chain
         run: |
-          ./scripts/launch_local_testnet.sh --testnet 0 --nodes 4 --stop-at-epoch 5 --log-level DEBUG --disable-htop --enable-logtrace --data-dir local_testnet0_data --base-port $(( 9000 + EXECUTOR_NUMBER * 100 )) --base-rpc-port $(( 7000 + EXECUTOR_NUMBER * 100 )) --base-metrics-port $(( 8008 + EXECUTOR_NUMBER * 100 )) -- --verify-finalization --discv5:no
+          ./scripts/launch_local_testnet.sh --testnet 0 --nodes 4 --stop-at-epoch 5 --log-level DEBUG --disable-htop --enable-logtrace --data-dir local_testnet0_data --base-port 9000 --base-rpc-port 7000  --base-metrics-port 8008 -- --verify-finalization --discv5:no
 
       - name: Run nim-beacon-chain testnet1 (mainnet)
         if: matrix.target.TEST_KIND == 'finalization-mainnet'
         shell: bash
         working-directory: nim-beacon-chain
         run: |
-          ./scripts/launch_local_testnet.sh --testnet 1 --nodes 4 --stop-at-epoch 5 --log-level DEBUG --disable-htop --enable-logtrace --data-dir local_testnet0_data --base-port $(( 9000 + EXECUTOR_NUMBER * 100 )) --base-rpc-port $(( 7000 + EXECUTOR_NUMBER * 100 )) --base-metrics-port $(( 8008 + EXECUTOR_NUMBER * 100 )) -- --verify-finalization --discv5:no
+          ./scripts/launch_local_testnet.sh --testnet 1 --nodes 4 --stop-at-epoch 5 --log-level DEBUG --disable-htop --enable-logtrace --data-dir local_testnet0_data --base-port 9000 --base-rpc-port 7000 --base-metrics-port 8008 -- --verify-finalization --discv5:no

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ git config --global core.longpaths true
 You can now follow those instructions in the previous section by replacing `make` with `mingw32-make` (regardless of your 32-bit or 64-bit architecture):
 
 ```bash
-mingw32-make test # run the test suite
+mingw32-make -j $(nproc) test # run the test suite
 ```
 
 ### Linux, MacOS
@@ -358,15 +358,15 @@ After cloning the repo:
 # The first `make` invocation will update all Git submodules.
 # You'll run `make update` after each `git pull`, in the future, to keep those submodules up to date.
 
-# Build nimbus_beacon_node and all the tools, using 4 parallel Make jobs
-make -j4
+# Build nimbus_beacon_node and all the tools, using as many parallel jobs as you have CPU cores
+make -j $(nproc)
 
 # Run tests
-make test
+make -j $(nproc) test
 
 # Update to latest version
 git pull
-make update
+make -j $(nproc) update
 ```
 
 To run a command that might use binaries from the Status Nim fork:
@@ -411,7 +411,7 @@ sudo apt-get install git
 
 ```bash
 # $(nproc) corresponds to the number of cores you have
-make -j$(nproc)
+make -j $(nproc)
 ```
 
 - build a specific tool:

--- a/config.nims
+++ b/config.nims
@@ -11,8 +11,8 @@ if defined(release) and not defined(disableLTO):
     switch("passC", "-flto=thin")
     switch("passL", "-flto=thin -Wl,-object_path_lto," & nimCachePath & "/lto")
   elif defined(linux):
-    switch("passC", "-flto=auto")
-    switch("passL", "-flto=auto")
+    switch("passC", "-flto=jobserver")
+    switch("passL", "-flto=jobserver")
     switch("passC", "-finline-limit=100000")
     switch("passL", "-finline-limit=100000")
   else:

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -185,11 +185,13 @@ else
   MAKE="make"
 fi
 
-NETWORK_NIM_FLAGS=$(scripts/load-testnet-nim-flags.sh "${NETWORK}")
-$MAKE -j2 LOG_LEVEL="${LOG_LEVEL}" NIMFLAGS="${NIMFLAGS} -d:insecure -d:testnet_servers_image -d:local_testnet ${NETWORK_NIM_FLAGS}" nimbus_beacon_node nimbus_signing_process nimbus_validator_client deposit_contract
+# Build the binaries
+BINARIES="nimbus_beacon_node nimbus_signing_process nimbus_validator_client deposit_contract"
 if [[ "$ENABLE_LOGTRACE" == "1" ]]; then
-  $MAKE LOG_LEVEL="${LOG_LEVEL}" NIMFLAGS="${NIMFLAGS} -d:insecure -d:testnet_servers_image -d:local_testnet ${NETWORK_NIM_FLAGS}" logtrace
+  BINARIES="${BINARIES} logtrace"
 fi
+NETWORK_NIM_FLAGS=$(scripts/load-testnet-nim-flags.sh "${NETWORK}")
+$MAKE -j $(nproc) LOG_LEVEL="${LOG_LEVEL}" NIMFLAGS="${NIMFLAGS} -d:insecure -d:testnet_servers_image -d:local_testnet ${NETWORK_NIM_FLAGS}" ${BINARIES}
 
 PIDS=""
 WEB3_ARG=""

--- a/tools/generate_makefile.nim
+++ b/tools/generate_makefile.nim
@@ -1,0 +1,94 @@
+# Copyright (c) 2020 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# Generate a Makefile from the JSON file produce by the Nim compiler with
+# "--compileOnly". Suitable for Make-controlled parallelisation, down to the GCC
+# LTO level.
+
+import json, os, strutils
+
+# Ripped off from Nim's `linkViaResponseFile()` in "compiler/extccomp.nim".
+# It lets us get around a command line length limit on Windows.
+proc processLinkCmd(cmd, linkerArgs: string): string =
+  # Extracting the linker.exe here is a bit hacky but the best solution
+  # given ``buildLib``'s design.
+  var
+    i = 0
+    last = 0
+
+  if cmd.len > 0 and cmd[0] == '"':
+    inc i
+    while i < cmd.len and cmd[i] != '"': inc i
+    last = i
+    inc i
+  else:
+    while i < cmd.len and cmd[i] != ' ': inc i
+    last = i
+
+  while i < cmd.len and cmd[i] == ' ': inc i
+
+  let args = cmd.substr(i)
+  writeFile(linkerArgs, args.replace('\\', '/'))
+
+  return cmd.substr(0, last) & " @" & linkerArgs
+
+proc main() =
+  let nrParams = paramCount()
+
+  if nrParams != 2:
+    echo "Usage: ", paramStr(0), " input.json output.makefile"
+    quit(QuitFailure)
+
+  let
+    jsonPath = paramStr(1)
+    makefilePath = paramStr(2)
+
+  if not fileExists(jsonPath):
+    echo "No such file: ", jsonPath
+    quit(QuitFailure)
+
+  let
+    data = json.parseFile(jsonPath)
+    makefile = open(makefilePath, fmWrite)
+
+  defer:
+    makefile.close()
+
+  var
+    objectPath: string
+    found: bool
+    cmd: string
+
+  for compile in data["compile"]:
+    cmd = compile[1].getStr()
+    objectPath = ""
+    found = false
+    for token in split(cmd):
+      if found and token.len > 0 and token.endsWith(".o"):
+        objectPath = token
+        break
+      if token == "-o":
+        found = true
+    if found == false or objectPath == "":
+      echo "Could not find the object file in this command: ", cmd
+      quit(QuitFailure)
+    makefile.writeLine("$#: $#" % [objectPath, compile[0].getStr()])
+    makefile.writeLine("\t+ $#\n" % cmd)
+
+  var objects: seq[string]
+  for obj in data["link"]:
+    objects.add(obj.getStr())
+  makefile.writeLine("OBJECTS := $#\n" % objects.join(" \\\n"))
+
+  makefile.writeLine(".PHONY: build")
+  makefile.writeLine("build: $(OBJECTS)")
+  makefile.writeLine("\t+ $#" % processLinkCmd(data["linkcmd"].getStr(), makefilePath & ".linkerArgs"))
+  if data.hasKey("extraCmds"):
+    for cmd in data["extraCmds"]:
+      makefile.writeLine("\t+ $#" % cmd.getStr())
+
+main()
+


### PR DESCRIPTION
This PR reduces peak RSS significantly during build (by 35% for `make nimbus_beacon_chain` on my system) making it feasible to build the software, without swapping, on systems with 2 GiB of RAM.

The first trick is to not keep the Nim compiler in memory during C compilation and linking. While it can be achieved with the undocumented "jsonscript" command - used when building the compiler itself - it does not help us with the second trick: controlling the maximum number of running processes.

When you run something like `make -j8`, you risk ending up with 8 `nim` + 8 \* 8 `gcc` or `lto-*` processes running at the same time, using up your RAM and wasting CPU cycles on scheduling. What we really need is a supervisor that every other process asks for slots from a limited pool - that's Make's jobserver.

Fortunately, GCC supports it for its internal LTO parallelisation, but only if the recipe launching it is prefixed with "+" and it manages to inherit a couple of open file descriptors from Make (used for inter-process communication). This last part is why we can't use `nim jsonscript ...`. So we take the JSON file produced with `nim c --compileOnly ...` and convert it into a makefile. All the commands Nim itself would run are there, so nothing is lost in the process.

Before we get to measurements, let us review the history of trying to measure the peak RSS of a process and all its children. First, there was `/usr/bin/time -v your_program`. Perfectly fine for a single process and its threads, but knows nothing about child processes. Then came this trick of calling `ps` on all the processes in a group, repeatedly, but it ignores shared memory, so it ends up overestimating the sum: https://gist.github.com/netj/526585 (further more, the results can vary significantly between runs)

Then someone remembered that control groups used to enforce memory limits also provide statistics. Files named "memory.max_usage_in_bytes" sure look enticing, right? Too bad they mix RSS, cache and swap. We can disable swap, but we can't get rid of that perfectly evictable filesystem cache. Maybe we can force an eviction with "memory.force_empty"? Nope. It leaves crumbs behind it.

Fortunately, there's "memory.stat" that gives us instantaneous RSS values. Remember that polling trick with `ps`? We can do the same here.

First, we create our memory cgroup, as root. "make_memory_cgroup.sh":

```bash
#!/usr/bin/env bash

set -v

cgdelete memory:test
cgcreate -a stefan:stefan -t stefan:stefan -g memory:test
echo 4G > /sys/fs/cgroup/memory/test/memory.limit_in_bytes
echo 4G > /sys/fs/cgroup/memory/test/memory.memsw.limit_in_bytes
```

Turns out that the only way to reset the kernel's memory-related statistics is to delete and recreate the cgroup for each benchmark run.

The modified polling script - "memusg_cgroup.sh":

```bash
#!/usr/bin/env bash

set -um

# check input
[[ $# -gt 0 ]] || { echo "Usage: $(basename $0) cmd [args]..."; exit 1; }

# monitor the memory usage in the background.
(
peak=0
sleep 1
while [[ $(cat /sys/fs/cgroup/memory/test/tasks | wc -l) != 0 ]]; do
  sample=$(grep "total_rss " /sys/fs/cgroup/memory/test/memory.stat | cut -d ' ' -f 2)
  let peak="sample > peak ? sample : peak"
  sleep 0.1
done
echo "peak RSS usage inside cgroup: ${peak} bytes" >&2
) &

# run the given command
exec "$@"
```

And now the results (we're running this as a regular user):

```text
rm -rf nimcache; ./memusg_cgroup.sh cgexec -g memory:test make nimbus_beacon_node
# before this PR:
peak RSS usage inside cgroup: 2302541824 bytes
# after this PR:
peak RSS usage inside cgroup: 1482403840 bytes
```

---

Since the magic parallelisation based on your number of CPU cores is gone, you'll want to use `make -j $(nproc) ...` on your development machine, even when compiling a single binary, to get the best speed.