### PR TITLE
Remove getSpecPreset() because of crash and add missing calls to documentation.

### DIFF
--- a/beacon_chain/rpc/nimbus_api.nim
+++ b/beacon_chain/rpc/nimbus_api.nim
@@ -64,24 +64,6 @@ proc installNimbusApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
   rpcServer.rpc("getNodeVersion") do () -> string:
     return "Nimbus/" & fullVersionStr
 
-  rpcServer.rpc("getSpecPreset") do () -> JsonNode:
-    var res = newJObject()
-    genStmtList:
-      for presetValue in PresetValue:
-        if presetValue notin ignoredValues + runtimeValues:
-          let
-            settingSym = ident($presetValue)
-            settingKey = newLit(toLowerAscii($presetValue))
-          let f = quote do:
-            res[`settingKey`] = %(presets.`settingSym`)
-          yield f
-
-    for field, value in fieldPairs(node.config.runtimePreset):
-      res[field] = when value isnot Version: %value
-                   else: %value.toUInt64
-
-    return res
-
   rpcServer.rpc("peers") do () -> JsonNode:
     var res = newJObject()
     var peers = newJArray()

--- a/docs/the_nimbus_book/src/api.md
+++ b/docs/the_nimbus_book/src/api.md
@@ -185,6 +185,68 @@ curl -d '{"jsonrpc":"2.0","method":"get_v1_debug_beacon_states_stateId","params"
 
 ## Nimbus extensions
 
+### getBeaconHead
+
+The latest head slot, as chosen by the latest fork choice.
+
+```
+curl -d '{"jsonrpc":"2.0","id":"id","method":"getBeaconHead","params":[] }' -H 'Content-Type: application/json' localhost:9190 -s | jq
+```
+
+### getChainHead
+
+Show chain head information, including head, justified and finalized checkpoints.
+
+```
+curl -d '{"jsonrpc":"2.0","id":"id","method":"getChainHead","params":[] }' -H 'Content-Type: application/json' localhost:9190 -s | jq
+```
+
+### getNodeVersion
+
+```
+ curl -d '{"jsonrpc":"2.0","method":"getNodeVersion","params":[],"id":1}' -H 'Content-Type: application/json' localhost:7001 -s | jq
+```
+
+### getSpecPreset
+
+```
+ curl -d '{"jsonrpc":"2.0","method":"getSpecPreset","params":[],"id":1}' -H 'Content-Type: application/json' localhost:7001 -s | jq
+```
+
+### peers
+
+Show a list of peers in PeerPool.
+
+```
+ curl -d '{"jsonrpc":"2.0","method":"peers","params":[],"id":1}' -H 'Content-Type: application/json' localhost:7001 -s | jq
+```
+
+### getSyncing
+
+Shows current state of forward syncing manager.
+
+```
+ curl -d '{"jsonrpc":"2.0","method":"getSyncing","params":[],"id":1}' -H 'Content-Type: application/json' localhost:7001 -s | jq
+```
+
+### getNetworkPeerId
+
+Shows current node's libp2p peer identifier (PeerID).
+
+```
+ curl -d '{"jsonrpc":"2.0","method":"getNetworkPeerId","params":[],"id":1}' -H 'Content-Type: application/json' localhost:7001 -s | jq
+```
+
+### getNetworkPeers
+
+Shows list of available PeerIDs in PeerPool.
+
+```
+ curl -d '{"jsonrpc":"2.0","method":"getNetworkPeers","params":[],"id":1}' -H 'Content-Type: application/json' localhost:7001 -s | jq
+```
+
+### getNetworkEnr
+
 ### setLogLevel
 
 Set the current logging level dynamically: TRACE, DEBUG, INFO, NOTICE, WARN, ERROR or FATAL


### PR DESCRIPTION
Fixes https://github.com/status-im/nimbus-eth2/issues/2104 by removing call and documentation.