### PR TITLE
Less risk for Eth1-induced delays in block proposal

### DIFF
--- a/beacon_chain/rpc/validator_api.nim
+++ b/beacon_chain/rpc/validator_api.nim
@@ -51,7 +51,7 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
     if head.slot >= body.message.slot:
       raise newException(CatchableError,
         "Proposal is for a past slot: " & $body.message.slot)
-    if head == await proposeSignedBlock(node, head, AttachedValidator(), body):
+    if head == proposeSignedBlock(node, head, AttachedValidator(), body):
       raise newException(CatchableError, "Could not propose block")
     return true
 


### PR DESCRIPTION
This spreads out the cost of updating the Eth1 data structures related to Eth2 finality over time. Previously, the same update would take place just before proposing a block, which may result in a delay contributing to the risk of the block being orphaned. I've been investigating the orphaned blocks of my own Pyrmont validator and I've been testing this branch carefully today. I'm quite confident that it also improves the status quo when it comes to various risks present within the first few minutes of restarting your node while it's still not fully synced with Eth1.

The `news` bump fixes a compatibility issue with the Besu Eth1 client.