### PR TITLE
Update ENR record with metadata attnets at each attestation subnet cycle

### DIFF
--- a/beacon_chain/eth2_discovery.nim
+++ b/beacon_chain/eth2_discovery.nim
@@ -14,7 +14,8 @@ type
   PublicKey = keys.PublicKey
 
 export
-  Eth2DiscoveryProtocol, open, start, close, closeWait, randomNodes, results
+  Eth2DiscoveryProtocol, open, start, close, closeWait, randomNodes,
+    updateRecord, results
 
 proc parseBootstrapAddress*(address: TaintedString):
     Result[enr.Record, cstring] =

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -433,6 +433,14 @@ proc cycleAttestationSubnets(node: BeaconNode, slot: Slot) {.async.} =
     for subnet in 0'u8 ..< ATTESTATION_SUBNET_COUNT:
       node.network.metadata.attnets[subnet] = subnet in subscribed_subnets
 
+  # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/p2p-interface.md#attestation-subnet-bitfield
+  let res = node.network.discovery.updateRecord(
+    {"attnets": SSZ.encode(node.network.metadata.attnets)})
+  if res.isErr():
+    # This should not occur in this scenario as the private key would always be
+    # the correct one and the ENR will not increase in size.
+    warn "Failed to update record on subnet cycle", error = res.error
+
 proc getAttestationSubnetHandlers(node: BeaconNode): Future[void] =
   var initialSubnets: set[uint8]
   for i in 0'u8 ..< ATTESTATION_SUBNET_COUNT:


### PR DESCRIPTION
Fix for https://github.com/status-im/nimbus-eth2/issues/2145 

two remarks:
- The updateRecord call currently does not actively ping any nodes in the local routing table. This could/should be added in order the get the new ENR spread much faster over the DHT
- Considering that now this was set to `0xFFFFFFFFFFFFFFFF` at init, this could effect our incoming connections based on discovery. But only if peers would filter at discovery on attnets enr field AND after connection, not check the metadata.attnets field. So I don't think it is really an issue, and anyhow the correct thing to do.