### PR TITLE
Disconnect peers on status handshake timeout.

### DIFF
--- a/beacon_chain/sync_protocol.nim
+++ b/beacon_chain/sync_protocol.nim
@@ -114,7 +114,8 @@ p2pProtocol BeaconSync(version = 1,
                               ourStatus, theirStatus.get())
     else:
       debug "Status response not received in time",
-        peer, error = theirStatus.error
+            peer, error = theirStatus.error
+      await peer.disconnect(FaultOrError)
 
   proc status(peer: Peer,
               theirStatus: StatusMsg,


### PR DESCRIPTION
We need explicitly disconnect peers when status handshake is not established in reasonable time, otherwise nodes could stuck in `Connecting` state.