### PR TITLE
use new stew helpers for assignment

### DIFF
--- a/beacon_chain/block_pools/chain_dag.nim
+++ b/beacon_chain/block_pools/chain_dag.nim
@@ -9,6 +9,7 @@
 
 import
   std/[options, sequtils, tables, sets],
+  stew/assign2,
   metrics, snappy, chronicles,
   ../ssz/[ssz_serialization, merkleization], ../beacon_chain_db, ../extras,
   ../spec/[

--- a/beacon_chain/block_pools/clearance.nim
+++ b/beacon_chain/block_pools/clearance.nim
@@ -10,7 +10,7 @@
 import
   std/tables,
   chronicles,
-  stew/results,
+  stew/[assign2, results],
   ../extras, ../time,
   ../spec/[crypto, datatypes, digest, helpers, signatures, state_transition],
   ./block_pools_types, ./chain_dag, ./quarantine

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -84,7 +84,6 @@ proc init*(T: type BeaconNode,
 
   var
     genesisState, checkpointState: ref BeaconState
-    genesisDepositsSnapshot: DepositContractSnapshot
     checkpointBlock: SignedBeaconBlock
 
   if conf.finalizedCheckpointState.isSome:

--- a/beacon_chain/validator_duties.nim
+++ b/beacon_chain/validator_duties.nim
@@ -10,7 +10,7 @@ import
   std/[os, osproc, random, sequtils, streams, tables],
 
   # Nimble packages
-  stew/[objects], stew/shims/macros,
+  stew/[assign2, objects, shims/macros],
   chronos, metrics, json_rpc/[rpcserver, jsonmarshal],
   chronicles,
   json_serialization/std/[options, sets, net], serialization/errors,
@@ -18,15 +18,15 @@ import
   eth/[keys, async_utils], eth/p2p/discoveryv5/[protocol, enr],
 
   # Local modules
-  spec/[datatypes, digest, crypto, helpers, network, signatures],
-  spec/state_transition,
-  conf, time, validator_pool,
-  attestation_pool, exit_pool, block_pools/[spec_cache, chain_dag, clearance],
-  eth2_network, keystore_management, beacon_node_common, beacon_node_types,
-  nimbus_binary_common,
-  eth1_monitor, version, ssz/merkleization,
-  attestation_aggregation, sync_manager, sszdump,
-  validator_slashing_protection
+  ./spec/[
+    datatypes, digest, crypto, helpers, network, signatures, state_transition],
+  ./conf, ./time, ./validator_pool,
+  ./attestation_pool, ./exit_pool,
+  ./block_pools/[spec_cache, chain_dag, clearance],
+  ./eth2_network, ./keystore_management, ./beacon_node_common,
+  ./beacon_node_types, ./nimbus_binary_common, ./eth1_monitor, ./version,
+  ./ssz/merkleization, ./attestation_aggregation, ./sync_manager, ./sszdump,
+  ./validator_slashing_protection
 
 # Metrics for tracking attestation and beacon block loss
 const delayBuckets = [-Inf, -4.0, -2.0, -1.0, -0.5, -0.1, -0.05,

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -8,7 +8,8 @@
 {.used.}
 
 import
-  options, sequtils, unittest,
+  std/[options, sequtils, unittest],
+  stew/assign2,
   ./testutil, ./testblockutil,
   ../beacon_chain/spec/[datatypes, digest, helpers, state_transition, presets],
   ../beacon_chain/[beacon_node_types, ssz],


### PR DESCRIPTION
* bump libp2p (reduces libp2p gossip memory usage to ~1/3)
* use "generic" assign version