### PR TITLE
new Make target: "benchmarks"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,5 @@ build/
 beacon_chain/sync_protocol.nim.generated.nim
 
 /dist
+/benchmark_results
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -198,3 +198,8 @@
 	url = https://github.com/status-im/nim-zxcvbn.git
 	ignore = dirty
 	branch = master
+[submodule "vendor/nimbus-benchmarking"]
+	path = vendor/nimbus-benchmarking
+	url = https://github.com/status-im/nimbus-benchmarking.git
+	ignore = dirty
+	branch = master

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,8 @@ TOOLS_CSV := $(subst $(SPACE),$(COMMA),$(TOOLS))
 	libbacktrace \
 	book \
 	publish-book \
-	dist
+	dist \
+	benchmarks
 
 ifeq ($(NIM_PARAMS),)
 # "variables.mk" was not included, so we update the submodules.
@@ -406,5 +407,12 @@ dist-test:
 			DOCKER_BUILDKIT=1 docker build -f Dockerfile.$${DISTRO} -t nimbus-eth2-dist-test --progress=plain --build-arg USER_ID=$$(id -u) --build-arg GROUP_ID=$$(id -g) . && \
 			docker run --rm --name nimbus-eth2-dist-test -v $(CURDIR):/home/user/nimbus-eth2 nimbus-eth2-dist-test; \
 		done
+
+#- Build and run benchmarks using an external repo (which can be used easily on
+#  older commits, before this Make target was added).
+#- It's up to the user to create a benchmarking environment that minimises the
+#  results spread. We're showing a 95% CI bar to help visualise that.
+benchmarks:
+	+ vendor/nimbus-benchmarking/run_nbc_benchmarks.sh --output-type d3
 
 endif # "variables.mk" was not included

--- a/docs/the_nimbus_book/src/developers.md
+++ b/docs/the_nimbus_book/src/developers.md
@@ -113,6 +113,12 @@ make -j$(nproc) NIMFLAGS="-d:release" USE_MULTITAIL=yes eth2_network_simulation
 make USE_LIBBACKTRACE=0 # expect the resulting binaries to be 2-3 times slower
 ```
 
+- run some benchmarks and generate HTML charts
+
+```bash
+make benchmarks
+```
+
 ### Multi-client interop scripts
 
 [This repository](https://github.com/eth2-clients/multinet) contains a set of scripts used by the client implementation teams to test interop between the clients (in certain simplified scenarios). It mostly helps us find and debug issues.


### PR DESCRIPTION
It runs some benchmarks, collects the output and generates HTML charts.

Addresses https://github.com/status-im/nimbus-eth2/issues/1145

Example HTML page generated for a benchmark group:

![img](https://i.imgur.com/6arEnCm.png)

Time axis labels can get ugly sometimes, but I don't want to debug Dimple.js to find out why.

TODO: some chart zooming functionality. D3 has a widget, but D3 is rather hard to use. Dimple does not seem interested in implementing it. Maybe we can come up with a dirty hack of our own.