### PR TITLE
make subnet cycling more robust; use one stability subnet/validator; explicitly represent gossip enabled/disabled

### DIFF
--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -1626,7 +1626,7 @@ proc addValidator*[MsgType](node: Eth2Node,
   node.pubsub.addValidator(topic & "_snappy", execValidator)
 
 proc unsubscribe*(node: Eth2Node, topic: string): Future[void] =
-  node.pubsub.unsubscribeAll(topic & "_snappy")
+  node.pubsub.unsubscribeAll(topic)
 
 proc traceMessage(fut: FutureBase, msgId: seq[byte]) =
   fut.addCallback do (arg: pointer):

--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -1626,7 +1626,7 @@ proc addValidator*[MsgType](node: Eth2Node,
   node.pubsub.addValidator(topic & "_snappy", execValidator)
 
 proc unsubscribe*(node: Eth2Node, topic: string): Future[void] =
-  node.pubsub.unsubscribeAll(topic)
+  node.pubsub.unsubscribeAll(topic & "_snappy")
 
 proc traceMessage(fut: FutureBase, msgId: seq[byte]) =
   fut.addCallback do (arg: pointer):

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -395,8 +395,6 @@ proc cycleAttestationSubnets(node: BeaconNode, wallSlot: Slot) {.async.} =
       stateSlot = node.chainDag.headState.data.data.slot
     return
 
-  # As a result, allow callers to effectively poll this function and only
-  # cycle at most once per epoch.
   if node.attestationSubnets.nextCycleEpoch > wallSlot.epoch:
     return
   node.attestationSubnets.nextCycleEpoch = wallSlot.epoch + 1

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -359,11 +359,12 @@ proc installAttestationSubnetHandlers(node: BeaconNode, subnets: set[uint8])
 
   await allFutures(attestationSubscriptions)
 
-proc updateStabilitySubnetMetadata(node: BeaconNode, stabilitySubnet: uint64) =
+proc updateStabilitySubnetMetadata(
+    node: BeaconNode, stabilitySubnets: set[uint8]) =
   # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/p2p-interface.md#metadata
   node.network.metadata.seq_number += 1
   for subnet in 0'u8 ..< ATTESTATION_SUBNET_COUNT:
-    node.network.metadata.attnets[subnet] = (subnet == stabilitySubnet)
+    node.network.metadata.attnets[subnet] = (subnet in stabilitySubnets)
 
   # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/validator.md#phase-0-attestation-subnet-stability
   # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/p2p-interface.md#attestation-subnet-bitfield
@@ -374,12 +375,33 @@ proc updateStabilitySubnetMetadata(node: BeaconNode, stabilitySubnet: uint64) =
     # be the correct one and the ENR will not increase in size.
     warn "Failed to update record on subnet cycle", error = res.error
   else:
-    debug "Stability subnet changed, updated ENR attnets", stabilitySubnet
+    debug "Stability subnets changed; updated ENR attnets", stabilitySubnets
 
-proc cycleAttestationSubnets(node: BeaconNode, slot: Slot) {.async.} =
+func getStabilitySubnets(stabilitySubnets: auto): set[uint8] =
+  for subnetInfo in stabilitySubnets:
+    result.incl subnetInfo.subnet
+
+proc cycleAttestationSubnets(node: BeaconNode, wallSlot: Slot) {.async.} =
   static: doAssert RANDOM_SUBNETS_PER_VALIDATOR == 1
 
-  let epochParity = slot.epoch mod 2
+  # Only know RANDAO mix, which determines shuffling seed, one epoch in
+  # advance. When node.chainDag.headState.data.data.slot.epoch is ahead
+  # of wallSlot, the clock's just incorrect. If the state slot's behind
+  # wallSlot, it would have to look more than MIN_SEED_LOOKAHEAD epochs
+  # ahead to compute the shuffling determining the beacon committees.
+  if node.chainDag.headState.data.data.slot.epoch != wallSlot.epoch:
+    debug "Requested attestation subnets too far in advance",
+      wallSlot,
+      stateSlot = node.chainDag.headState.data.data.slot
+    return
+
+  # As a result, allow callers to effectively poll this function and only
+  # cycle at most once per epoch.
+  if node.attestationSubnets.nextCycleEpoch > wallSlot.epoch:
+    return
+  node.attestationSubnets.nextCycleEpoch = wallSlot.epoch + 1
+
+  let epochParity = wallSlot.epoch mod 2
   var attachedValidators: seq[ValidatorIndex]
   for validatorIndex in 0 ..< node.chainDag.headState.data.data.validators.len:
     if node.getAttachedValidator(
@@ -392,9 +414,10 @@ proc cycleAttestationSubnets(node: BeaconNode, slot: Slot) {.async.} =
   let (newAttestationSubnets, expiringSubnets, newSubnets) =
     get_attestation_subnet_changes(
       node.chainDag.headState.data.data, attachedValidators,
-      node.attestationSubnets, slot.epoch)
+      node.attestationSubnets)
 
-  let prevStabilitySubnet = node.attestationSubnets.stabilitySubnet
+  let prevStabilitySubnets =
+    getStabilitySubnets(node.attestationSubnets.stabilitySubnets)
 
   node.attestationSubnets = newAttestationSubnets
   debug "Attestation subnets",
@@ -403,9 +426,8 @@ proc cycleAttestationSubnets(node: BeaconNode, slot: Slot) {.async.} =
       node.attestationSubnets.subscribedSubnets[1 - epochParity],
     upcoming_subnets = node.attestationSubnets.subscribedSubnets[epochParity],
     new_subnets = newSubnets,
-    stability_subnet = node.attestationSubnets.stabilitySubnet,
-    stability_subnet_expiration_epoch =
-      node.attestationSubnets.stabilitySubnetExpirationEpoch
+    epoch = wallSlot.epoch,
+    num_stability_subnets = node.attestationSubnets.stabilitySubnets.len
 
   block:
     var unsubscriptions: seq[Future[void]] = @[]
@@ -417,9 +439,10 @@ proc cycleAttestationSubnets(node: BeaconNode, slot: Slot) {.async.} =
 
   await node.installAttestationSubnetHandlers(newSubnets)
 
-  let stabilitySubnet = node.attestationSubnets.stabilitySubnet
-  if stabilitySubnet != prevStabilitySubnet:
-    node.updateStabilitySubnetMetadata(stabilitySubnet)
+  let stabilitySubnets =
+    getStabilitySubnets(node.attestationSubnets.stabilitySubnets)
+  if stabilitySubnets != prevStabilitySubnets:
+    node.updateStabilitySubnetMetadata(stabilitySubnets)
 
 proc getAttestationSubnetHandlers(node: BeaconNode): Future[void] =
   var initialSubnets: set[uint8]
@@ -432,17 +455,26 @@ proc getAttestationSubnetHandlers(node: BeaconNode): Future[void] =
   # - Restarting the node with a presistent netkey
   # - When going from synced -> syncing -> synced state
   let wallEpoch =  node.beaconClock.now().slotOrZero().epoch
-  node.attestationSubnets.stabilitySubnet = rand(ATTESTATION_SUBNET_COUNT - 1).uint64
-  node.attestationSubnets.stabilitySubnetExpirationEpoch =
-    wallEpoch + getStabilitySubnetLength()
+  doAssert node.attestationSubnets.stabilitySubnets.len == 0
+  for _ in 0 ..< node.attachedValidators.count:
+    node.attestationSubnets.stabilitySubnets.add (
+      subnet: rand(ATTESTATION_SUBNET_COUNT - 1).uint8,
+      expiration: wallEpoch + getStabilitySubnetLength())
 
-  node.updateStabilitySubnetMetadata(node.attestationSubnets.stabilitySubnet)
+  node.updateStabilitySubnetMetadata(
+    node.attestationSubnets.stabilitySubnets.getStabilitySubnets)
 
   # Sets the "current" and "future" attestation subnets. One of these gets
-  # replaced by get_attestation_subnet_changes() immediately.
+  # replaced by get_attestation_subnet_changes() immediately. Symmetric so
+  # that it's robust to the exact timing of when cycleAttestationSubnets()
+  # first runs, by making that first (effective) swap a no-op.
   node.attestationSubnets.subscribedSubnets[0] = initialSubnets
   node.attestationSubnets.subscribedSubnets[1] = initialSubnets
+  node.attestationSubnets.enabled = true
 
+  debug "Initial attestation subnets subscribed",
+     initialSubnets,
+     wallEpoch
   node.installAttestationSubnetHandlers(initialSubnets)
 
 proc addMessageHandlers(node: BeaconNode): Future[void] =
@@ -457,12 +489,13 @@ proc addMessageHandlers(node: BeaconNode): Future[void] =
   )
 
 func getTopicSubscriptionEnabled(node: BeaconNode): bool =
-  node.attestationSubnets.subscribedSubnets[0].len +
-  node.attestationSubnets.subscribedSubnets[1].len > 0
+  node.attestationSubnets.enabled
 
 proc removeMessageHandlers(node: BeaconNode): Future[void] =
   node.attestationSubnets.subscribedSubnets[0] = {}
   node.attestationSubnets.subscribedSubnets[1] = {}
+  node.attestationSubnets.enabled = false
+  node.attestationSubnets.stabilitySubnets.setLen(0)
   doAssert not node.getTopicSubscriptionEnabled()
 
   var unsubscriptions = mapIt(
@@ -526,8 +559,9 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
       syncQueueLen
     await node.removeMessageHandlers()
 
-  # Subscription or unsubscription might have occurred; recheck
-  if slot.isEpoch and node.getTopicSubscriptionEnabled:
+  # Subscription or unsubscription might have occurred; recheck.
+  if node.getTopicSubscriptionEnabled:
+    # This exits early all but one call each epoch.
     await node.cycleAttestationSubnets(slot)
 
 proc onSlotEnd(node: BeaconNode, slot, nextSlot: Slot): Future[void] =

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -266,7 +266,7 @@ proc onSlotStart(vc: ValidatorClient, lastSlot, scheduledSlot: Slot) {.gcsafe, a
     # need similar amounts of memory.
     GC_fullCollect()
 
-  if (slot - 2).isEpoch:
+  if (slot - 2).isEpoch and (slot.epoch + 1) in vc.attestationsForEpoch:
     for slot, attesterDuties in vc.attestationsForEpoch[slot.epoch + 1].pairs:
       for ad in attesterDuties:
         let

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -87,7 +87,6 @@ proc getValidatorDutiesForEpoch(vc: ValidatorClient, epoch: Epoch) {.gcsafe, asy
   vc.attestationsForEpoch.clear()
   await getAttesterDutiesForEpoch(epoch)
   # obtain the attestation duties this VC should do during the next epoch
-  # TODO currently we aren't making use of this but perhaps we should
   await getAttesterDutiesForEpoch(epoch + 1)
 
   # for now we will get the fork each time we update the validator duties for each epoch
@@ -129,6 +128,9 @@ proc onSlotStart(vc: ValidatorClient, lastSlot, scheduledSlot: Slot) {.gcsafe, a
     # 1 slot earlier because there are a few back-and-forth requests which
     # could take up time for attesting... Perhaps this should be called more
     # than once per epoch because of forks & other events...
+    #
+    # calling it before epoch n starts means one can't ensure knowing about
+    # epoch n+1.
     if slot.isEpoch:
       await getValidatorDutiesForEpoch(vc, epoch)
 
@@ -263,6 +265,14 @@ proc onSlotStart(vc: ValidatorClient, lastSlot, scheduledSlot: Slot) {.gcsafe, a
     # temporary buffers etc) gets recycled for the next slot that is likely to
     # need similar amounts of memory.
     GC_fullCollect()
+
+  if (slot-1).isEpoch:
+    for slot, attesterDuties in vc.attestationsForEpoch[slot.epoch + 1].pairs:
+      for ad in attesterDuties:
+        # TODO actually calculat slot signature
+        discard await vc.client.post_v1_validator_beacon_committee_subscriptions(
+          ad.committee_index, ad.slot, true, ad.public_key,
+          default(ValidatorSig))
 
   addTimer(nextSlotStart) do (p: pointer):
     asyncCheck vc.onSlotStart(slot, nextSlot)

--- a/beacon_chain/rpc/validator_api.nim
+++ b/beacon_chain/rpc/validator_api.nim
@@ -126,7 +126,7 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
         "Beacon node is currently syncing and not serving request on that endpoint")
 
     let wallSlot = node.beaconClock.now.slotOrZero
-    if wallSlot > slot:
+    if wallSlot > 1 + slot:
       raise newException(CatchableError,
         "Past slot requested")
 

--- a/beacon_chain/rpc/validator_api.nim
+++ b/beacon_chain/rpc/validator_api.nim
@@ -15,7 +15,7 @@ import
   chronicles,
 
   # Local modules
-  ../spec/[datatypes, digest, crypto, helpers],
+  ../spec/[datatypes, digest, crypto, helpers, network],
   ../spec/eth2_apis/callsigs_types,
   ../block_pools/[chain_dag, spec_cache], ../ssz/merkleization,
   ../beacon_node_common, ../beacon_node_types, ../attestation_pool,
@@ -115,5 +115,35 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
   rpcServer.rpc("post_v1_validator_beacon_committee_subscriptions") do (
       committee_index: CommitteeIndex, slot: Slot, aggregator: bool,
       validator_pubkey: ValidatorPubKey, slot_signature: ValidatorSig) -> bool:
-    debug "post_v1_validator_beacon_committee_subscriptions"
-    raise newException(CatchableError, "Not implemented")
+    debug "post_v1_validator_beacon_committee_subscriptions",
+      committee_index, slot
+    if committee_index.uint64 >= ATTESTATION_SUBNET_COUNT.uint64:
+      raise newException(CatchableError,
+        "Invalid committee index")
+
+    when false:
+      if not node.syncManager.inProgress:
+        raise newException(CatchableError,
+          "Beacon node is currently syncing and not serving request on that endpoint")
+
+    let wallSlot = node.beaconClock.now.slotOrZero
+    if wallSlot > slot:
+      raise newException(CatchableError,
+        "Past slot requested")
+
+    let epoch = slot.epoch
+    if epoch - wallSlot.epoch notin [0'u64, 1'u64]:
+      raise newException(CatchableError,
+        "Slot requested not in current or next wall-slot epoch")
+    # TODO validate slot_signature
+
+    let subnet = committee_index.uint8
+    if  subnet notin node.attestationSubnets.subscribedSubnets[0] and
+        subnet notin node.attestationSubnets.subscribedSubnets[1]:
+      waitFor node.network.subscribe(getAttestationTopic(
+        node.forkDigest, subnet))
+
+    # But it might only be in current
+    # TODO only add it in correct one, based on nextEpoch
+    node.attestationSubnets.subscribedSubnets[0].incl subnet
+    node.attestationSubnets.subscribedSubnets[1].incl subnet

--- a/beacon_chain/rpc/validator_api.nim
+++ b/beacon_chain/rpc/validator_api.nim
@@ -131,7 +131,7 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
         "Past slot requested")
 
     let epoch = slot.epoch
-    if epoch - wallSlot.epoch notin [0'u64, 1'u64]:
+    if epoch >= wallSlot.epoch and epoch - wallSlot.epoch > 1:
       raise newException(CatchableError,
         "Slot requested not in current or next wall-slot epoch")
 

--- a/beacon_chain/rpc/validator_api.nim
+++ b/beacon_chain/rpc/validator_api.nim
@@ -126,7 +126,7 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
         "Beacon node is currently syncing and not serving request on that endpoint")
 
     let wallSlot = node.beaconClock.now.slotOrZero
-    if wallSlot > 1 + slot:
+    if wallSlot > slot + 1:
       raise newException(CatchableError,
         "Past slot requested")
 

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -457,9 +457,10 @@ type
     beacon_proposer_indices*: Table[Slot, Option[ValidatorIndex]]
 
   AttestationSubnets* = object
+    enabled*: bool
+    nextCycleEpoch*: Epoch
     subscribedSubnets*: array[2, set[uint8]]
-    stabilitySubnet*: uint64
-    stabilitySubnetExpirationEpoch*: Epoch
+    stabilitySubnets*: seq[tuple[subnet: uint8, expiration: Epoch]]
 
   # This matches the mutable state of the Solidity deposit contract
   # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/solidity_deposit_contract/deposit_contract.sol

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -124,42 +124,54 @@ proc getStabilitySubnetLength*(): uint64 =
 
 proc get_attestation_subnet_changes*(
     state: BeaconState, attachedValidators: openArray[ValidatorIndex],
-    prevAttestationSubnets: AttestationSubnets, epoch: Epoch):
+    prevAttestationSubnets: AttestationSubnets):
     tuple[a: AttestationSubnets, b: set[uint8], c: set[uint8]] =
   static: doAssert ATTESTATION_SUBNET_COUNT == 64  # Fits in a set[uint8]
   doAssert attachedValidators.len > 0
 
-  var attestationSubnets = prevAttestationSubnets
+  # Guaranteed equivalent to wallSlot by cycleAttestationSubnets(), especially
+  # since it'll try to run early in epochs, avoiding race conditions.
+  let epoch = state.slot.epoch
 
   # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/validator.md#phase-0-attestation-subnet-stability
-  let prevStabilitySubnet = {attestationSubnets.stabilitySubnet.uint8}
-  if epoch >= attestationSubnets.stabilitySubnetExpirationEpoch:
-    attestationSubnets.stabilitySubnet =
-      rand(ATTESTATION_SUBNET_COUNT - 1).uint64
-    attestationSubnets.stabilitySubnetExpirationEpoch =
-      epoch + getStabilitySubnetLength()
+  var
+    attestationSubnets = prevAttestationSubnets
+    prevStabilitySubnets: set[uint8] = {}
+    stabilitySet: set[uint8] = {}
+  for i in 0 ..< attestationSubnets.stabilitySubnets.len:
+    static: doAssert ATTESTATION_SUBNET_COUNT <= high(uint8)
+    prevStabilitySubnets.incl attestationSubnets.stabilitySubnets[i].subnet
+
+    if epoch >= attestationSubnets.stabilitySubnets[i].expiration:
+      attestationSubnets.stabilitySubnets[i].subnet =
+        rand(ATTESTATION_SUBNET_COUNT - 1).uint8
+      attestationSubnets.stabilitySubnets[i].expiration =
+        epoch + getStabilitySubnetLength()
+
+    stabilitySet.incl attestationSubnets.stabilitySubnets[i].subnet
 
   var nextEpochSubnets: set[uint8]
   for it in get_committee_assignments(
-      state, state.slot.epoch + 1, attachedValidators.toHashSet):
+      state, epoch + 1, attachedValidators.toHashSet):
     nextEpochSubnets.incl it.subnetIndex.uint8
 
   doAssert nextEpochSubnets.len <= attachedValidators.len
+  nextEpochSubnets.incl stabilitySet
 
   let
     epochParity = epoch mod 2
-    stabilitySet = {attestationSubnets.stabilitySubnet.uint8}
     currentEpochSubnets = attestationSubnets.subscribedSubnets[1 - epochParity]
 
     expiringSubnets =
-      (prevStabilitySubnet +
+      (prevStabilitySubnets +
         attestationSubnets.subscribedSubnets[epochParity]) -
         nextEpochSubnets - currentEpochSubnets - stabilitySet
     newSubnets =
-      (nextEpochSubnets + stabilitySet) -
-        (currentEpochSubnets + prevStabilitySubnet)
+      nextEpochSubnets - (currentEpochSubnets + prevStabilitySubnets)
 
   doAssert newSubnets.len <= attachedValidators.len + 1
+  doAssert (expiringSubnets * currentEpochSubnets).len == 0
+  doAssert newSubnets <= nextEpochSubnets
 
-  attestationSubnets.subscribedSubnets[epochParity] = newSubnets
+  attestationSubnets.subscribedSubnets[epochParity] = nextEpochSubnets
   (attestationSubnets, expiringSubnets, newSubnets)


### PR DESCRIPTION
https://github.com/status-im/nimbus-eth2/pull/2194 triggered assertions in the fleet because of issues with attestation subnet cycling, which resulted in it believing it wasn't supposed to be subscribed to any subnets, which was interpreted by `getTopicSubscriptionEnabled()` as gossip having been disabled, without the gossip-disabling code, which would have prevented that assertion from firing, from having been run.

To address this, this PR:
- adds an explicit `enabled` flag, rather than the implicit/inferred approach; and
- fixes the underlying glitch in the attestation cycling with large numbers of validators attached related to incorrect handling of overlapping subnets in successive epochs.

Furthermore, `get_attestation_subnet_changes` had been a bit inconsistent in whether it used wall time or slots. Ordinarily, they lined up, but results were not guaranteed when they did not, and it'd only been calling it once per epoch, whether the conditions were good for it yet or not. This effectively polls it once per slot until the wall-epoch and head-epoch align that epoch.

With 3 validators on Pyrmont, it looks like, for example:
```
{"lvl":"DBG","ts":"2020-12-20 13:46:33.445+00:00","msg":"Attestation subnets","topics":"beacnde","tid":99137,"file":"nimbus_beacon_node.nim:423","expiring_subnets":[],"current_epoch_subnets":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63],"upcoming_subnets":[13,14,25,42,44,57],"new_subnets":[],"epoch":7207,"num_stability_subnets":3}
{"lvl":"DBG","ts":"2020-12-20 13:51:27.308+00:00","msg":"Attestation subnets","topics":"beacnde","tid":99137,"file":"nimbus_beacon_node.nim:423","expiring_subnets":[0,1,2,3,4,5,6,7,8,9,10,11,15,16,18,19,20,21,22,23,24,26,27,28,29,30,31,32,33,34,35,36,37,38,39,41,43,45,46,47,48,49,50,51,52,53,54,55,56,58,59,60,61,62,63],"current_epoch_subnets":[13,14,25,42,44,57],"upcoming_subnets":[12,17,25,40,44,57],"new_subnets":[12,17,40],"epoch":7208,"num_stability_subnets":3}
{"lvl":"DBG","ts":"2020-12-20 13:57:51.236+00:00","msg":"Attestation subnets","topics":"beacnde","tid":99137,"file":"nimbus_beacon_node.nim:423","expiring_subnets":[13,14],"current_epoch_subnets":[12,17,25,40,44,57],"upcoming_subnets":[11,17,25,42,44,57],"new_subnets":[11,42],"epoch":7209,"num_stability_subnets":3}
{"lvl":"DBG","ts":"2020-12-20 14:04:15.299+00:00","msg":"Attestation subnets","topics":"beacnde","tid":99137,"file":"nimbus_beacon_node.nim:423","expiring_subnets":[12,40],"current_epoch_subnets":[11,17,25,42,44,57],"upcoming_subnets":[1,13,25,44,57,61],"new_subnets":[1,13,61],"epoch":7210,"num_stability_subnets":3}
{"lvl":"DBG","ts":"2020-12-20 14:10:39.277+00:00","msg":"Attestation subnets","topics":"beacnde","tid":99137,"file":"nimbus_beacon_node.nim:423","expiring_subnets":[11,17,42],"current_epoch_subnets":[1,13,25,44,57,61],"upcoming_subnets":[3,25,44,57,60,63],"new_subnets":[3,60,63],"epoch":7211,"num_stability_subnets":3}
{"lvl":"DBG","ts":"2020-12-20 14:17:03.301+00:00","msg":"Attestation subnets","topics":"beacnde","tid":99137,"file":"nimbus_beacon_node.nim:423","expiring_subnets":[13,61],"current_epoch_subnets":[3,25,44,57,60,63],"upcoming_subnets":[1,14,25,43,44,57],"new_subnets":[1,14,43],"epoch":7212,"num_stability_subnets":3}
```

The initial subscription to all 64 subnets is suboptimal, but out of scope of this PR to fix. This PR does shorten the average time to do so by running `cycleAttestationSubnets` an average of 3 or so minutes earlier.

In a local testnet:
```
{"lvl":"DBG","ts":"2020-12-20 14:16:50.584+00:00","msg":"Attestation subnets","topics":"beacnde","tid":844845,"file":"nimbus_beacon_node.nim:423","expiring_subnets":[],"current_epoch_subnets":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63],"upcoming_subnets":[1,3,8,9,10,11,15,16,19,20,24,25,26,29,30,31,33,34,35,36,40,50,53,55,62],"new_subnets":[],"epoch":0,"num_stability_subnets":15}
{"lvl":"DBG","ts":"2020-12-20 14:17:36.077+00:00","msg":"Attestation subnets","topics":"beacnde","tid":844845,"file":"nimbus_beacon_node.nim:423","expiring_subnets":[0,2,5,6,7,14,17,18,21,22,23,32,37,38,39,41,42,43,44,45,46,47,48,49,51,52,54,56,57,58,59,60,61,63],"current_epoch_subnets":[1,3,8,9,10,11,15,16,19,20,24,25,26,29,30,31,33,34,35,36,40,50,53,55,62],"upcoming_subnets":[1,3,4,8,9,12,13,19,24,25,26,27,28,29,30,31,33,34,35,36,40,50,53,55,62],"new_subnets":[4,12,13,27,28],"epoch":1,"num_stability_subnets":15}
{"lvl":"DBG","ts":"2020-12-20 14:18:24.084+00:00","msg":"Attestation subnets","topics":"beacnde","tid":844845,"file":"nimbus_beacon_node.nim:423","expiring_subnets":[10,11,15,16],"current_epoch_subnets":[1,3,4,8,9,12,13,19,24,25,26,27,28,29,30,31,33,34,35,36,40,50,53,55,62],"upcoming_subnets":[1,3,5,8,12,14,18,19,20,21,22,24,25,27,28,29,30,31,33,34,35,36,40,50,53,55,62],"new_subnets":[5,14,18,20,21,22],"epoch":2,"num_stability_subnets":15}
{"lvl":"DBG","ts":"2020-12-20 14:19:12.085+00:00","msg":"Attestation subnets","topics":"beacnde","tid":844845,"file":"nimbus_beacon_node.nim:423","expiring_subnets":[26],"current_epoch_subnets":[1,3,5,8,12,14,18,19,20,21,22,24,25,27,28,29,30,31,33,34,35,36,40,50,53,55,62],"upcoming_subnets":[1,2,3,4,8,9,10,11,12,13,15,16,17,18,19,23,24,30,31,33,34,35,36,40,50,53,55,62],"new_subnets":[2,4,9,10,11,13,15,16,17,23],"epoch":3,"num_stability_subnets":15}
{"lvl":"DBG","ts":"2020-12-20 14:20:00.086+00:00","msg":"Attestation subnets","topics":"beacnde","tid":844845,"file":"nimbus_beacon_node.nim:423","expiring_subnets":[5,20,21,25,28],"current_epoch_subnets":[1,2,3,4,8,9,10,11,12,13,15,16,17,18,19,23,24,30,31,33,34,35,36,40,50,53,55,62],"upcoming_subnets":[1,4,7,8,9,13,14,16,19,22,24,26,27,29,30,31,33,34,35,36,40,50,53,55,62],"new_subnets":[7,14,22,26,27,29],"epoch":4,"num_stability_subnets":15}
{"lvl":"DBG","ts":"2020-12-20 14:20:48.088+00:00","msg":"Attestation subnets","topics":"beacnde","tid":844845,"file":"nimbus_beacon_node.nim:423","expiring_subnets":[10,11,12,18,23],"current_epoch_subnets":[1,4,7,8,9,13,14,16,19,22,24,26,27,29,30,31,33,34,35,36,40,50,53,55,62],"upcoming_subnets":[1,2,3,8,9,15,16,17,19,21,24,27,30,31,33,34,35,36,40,50,53,55,62],"new_subnets":[2,3,15,17,21],"epoch":5,"num_stability_subnets":15}
{"lvl":"DBG","ts":"2020-12-20 14:21:48.084+00:00","msg":"Attestation subnets","topics":"beacnde","tid":844845,"file":"nimbus_beacon_node.nim:423","expiring_subnets":[7,13,14,22],"current_epoch_subnets":[1,2,3,8,9,15,16,17,19,21,24,27,30,31,33,34,35,36,40,50,53,55,62],"upcoming_subnets":[0,1,4,6,8,9,10,12,16,18,19,20,24,26,29,30,31,33,34,35,36,40,50,53,55,62],"new_subnets":[0,4,6,10,12,18,20,26,29],"epoch":6,"num_stability_subnets":15}
{"lvl":"DBG","ts":"2020-12-20 14:22:24.075+00:00","msg":"Attestation subnets","topics":"beacnde","tid":844845,"file":"nimbus_beacon_node.nim:423","expiring_subnets":[2,3,17,27],"current_epoch_subnets":[0,1,4,6,8,9,10,12,16,18,19,20,24,26,29,30,31,33,34,35,36,40,50,53,55,62],"upcoming_subnets":[1,5,8,10,13,15,18,19,20,21,24,25,26,29,30,31,33,34,35,36,40,50,53,55,62],"new_subnets":[5,13,15,21,25],"epoch":7,"num_stability_subnets":15}
{"lvl":"DBG","ts":"2020-12-20 14:23:12.076+00:00","msg":"Attestation subnets","topics":"beacnde","tid":844845,"file":"nimbus_beacon_node.nim:423","expiring_subnets":[0,4,9,12],"current_epoch_subnets":[1,5,8,10,13,15,18,19,20,21,24,25,26,29,30,31,33,34,35,36,40,50,53,55,62],"upcoming_subnets":[1,6,8,13,14,16,19,20,22,24,26,27,30,31,33,34,35,36,40,50,53,55,62],"new_subnets":[6,14,16,22,27],"epoch":8,"num_stability_subnets":15}
```
In particular, `current_epoch_subnets` and `upcoming_subnets` can now correctly overlap. They're each meant to be complete snapshots of a subnet subscription state, not diffs or any other incremental representation. The combination of a stability subnet per validator and more validators/node ensures this case is hit more consistently than the 3 validators/Pyrmont node example.