### PR TITLE
increase attestation pool lookback window

### DIFF
--- a/beacon_chain/beacon_node_types.nim
+++ b/beacon_chain/beacon_node_types.nim
@@ -14,7 +14,7 @@ export block_pools_types, ValidationResult
 
 const
   ATTESTATION_LOOKBACK* =
-    min(4'u64, SLOTS_PER_EPOCH) + MIN_ATTESTATION_INCLUSION_DELAY
+    min(24'u64, SLOTS_PER_EPOCH) + MIN_ATTESTATION_INCLUSION_DELAY
     ## The number of slots we'll keep track of in terms of "free" attestations
     ## that potentially could be added to a newly created block
 


### PR DESCRIPTION
Since repeated attestations aren't included in blocks anymore, include a broader slot range of valid attestations.