### PR TITLE
scripts: make shebang more portable

### DIFF
--- a/scripts/copyfile.sh
+++ b/scripts/copyfile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) 2018-2019 Status Research & Development GmbH. Licensed under
 # either of:

--- a/scripts/make_prometheus_config.sh
+++ b/scripts/make_prometheus_config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) 2020 Status Research & Development GmbH. Licensed under
 # either of:

--- a/scripts/makedir.sh
+++ b/scripts/makedir.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) 2018-2020 Status Research & Development GmbH. Licensed under
 # either of:

--- a/wasm/build.sh
+++ b/wasm/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Simple build script to produce an Emscripten-based wasm version of the state
 # sim.

--- a/wasm/build_ncli.sh
+++ b/wasm/build_ncli.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Simple build script to produce an Emscripten-based wasm version of the state
 # sim.


### PR DESCRIPTION
Some Linux distros (like NixOS) don't place bash in /bin/bash.