### PR TITLE
dist: bootstrap the Nim compiler with a default number of iterations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* bootstrap the Nim compiler with a default number of iterations
+
 2021-01-09 v1.0.5
 =================
 

--- a/docker/dist/entry_point.sh
+++ b/docker/dist/entry_point.sh
@@ -19,7 +19,6 @@ make \
   LOG_LEVEL="TRACE" \
   NIMFLAGS="-d:disableMarchNative" \
   PARTIAL_STATIC_LINKING=1 \
-  QUICK_AND_DIRTY_COMPILER=1 \
   ${BINARIES}
 
 # archive directory (we need the Nim compiler in here)


### PR DESCRIPTION
Reducing those iterations results in a buggy compiler that causes `nimbus_beacon_node` to fail at runtime with:
`FAT 2021-01-09 21:19:52.417+01:00 Could not obtain PeerID from network key   topics="networking" tid=26805 file=eth2_network.nim:1393`