### PR TITLE
Warn on Eth1 chain not synced

### DIFF
--- a/beacon_chain/eth1_monitor.nim
+++ b/beacon_chain/eth1_monitor.nim
@@ -616,7 +616,7 @@ proc trackFinalizedState*(chain: var Eth1Chain,
 
   let latest = chain.blocks.peekLast
   if latest.voteData.deposit_count < finalizedEth1Data.deposit_count:
-    debug "Eth1 chain not synced",
+    warn "Eth1 chain not synced",
           ourDepositsCount = latest.voteData.deposit_count,
           targetDepositsCount = finalizedEth1Data.deposit_count
     return false


### PR DESCRIPTION
Warn when it is noticed that eth1 is out of sync.

Note that this doesn't mean that when eth1 is not syncing this will be logged, but rather the moment that the deposits also are out of sync.