### PR TITLE
update libp2p branch when unstable changes

### DIFF
--- a/.github/workflows/update-libp2p-branch.yml
+++ b/.github/workflows/update-libp2p-branch.yml
@@ -1,0 +1,29 @@
+name: Update libp2p branch
+on:
+  push:
+    branches:
+      - unstable
+  workflow_dispatch:
+
+jobs:
+  bumpProjects:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Update libp2p branch
+        run: |
+          cd vendor/nim-libp2p
+          git checkout unstable
+
+      - name: Commit this update
+        run: |
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+          git config --global user.name = "${{ github.actor }}"
+          git commit --allow-empty -a -m "update nimbus unstable and auto-bump nim-libp2p"
+          git branch -D nim-libp2p-auto-bump-${GITHUB_REF##*/} || true
+          git switch -c nim-libp2p-auto-bump-${GITHUB_REF##*/}
+          git push -f origin nim-libp2p-auto-bump-${GITHUB_REF##*/}

--- a/.github/workflows/update-libp2p-branch.yml
+++ b/.github/workflows/update-libp2p-branch.yml
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2020-2024 Status Research & Development GmbH
+# Copyright (c) 2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/.github/workflows/update-libp2p-branch.yml
+++ b/.github/workflows/update-libp2p-branch.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Update libp2p branch
         run: |
           cd vendor/nim-libp2p
-          git checkout unstable
+          git checkout master
 
       - name: Commit this update
         run: |

--- a/.github/workflows/update-libp2p-branch.yml
+++ b/.github/workflows/update-libp2p-branch.yml
@@ -1,3 +1,10 @@
+# beacon_chain
+# Copyright (c) 2020-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 name: Update libp2p branch
 on:
   push:


### PR DESCRIPTION
This PR automates updating the libp2p branch when the Nimbus unstable branch changes. The libp2p branch will contain the latest Nimbus and nim-libp2p unstable.