### PR TITLE
Pin Docker base image to debian:trixie-slim; add ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,12 @@
 # at your option. This file may not be copied, modified, or distributed except
 # according to those terms.
 
-FROM debian:testing-slim AS build
+FROM debian:trixie-slim AS build
 
 SHELL ["/bin/bash", "-c"]
 
 RUN apt-get clean && apt update \
- && apt -y install build-essential git-lfs
+ && apt -y install build-essential git-lfs ca-certificates
 
 RUN ldd --version ldd
 
@@ -26,7 +26,7 @@ RUN cd /root/nimbus-eth2 \
 # --------------------------------- #
 # Starting new image to reduce size #
 # --------------------------------- #
-FROM debian:testing-slim as deploy
+FROM debian:trixie-slim as deploy
 
 SHELL ["/bin/bash", "-c"]
 RUN apt-get clean && apt update \


### PR DESCRIPTION
## Summary

- Pin top-level `Dockerfile` base image from `debian:testing-slim` → `debian:trixie-slim` (Debian 13 stable) in both `build` and `deploy` stages
- Add `ca-certificates` to the build-stage apt install so HTTPS submodule clones in `make update` keep working (not preinstalled in the slim image)

## Why

### GCC 15 LTO internal compiler error

`debian:testing-slim` currently ships `gcc-15` (15.2.0). Building the image fails deterministically in the `nimbus_beacon_node` / `nimbus_validator_client` compile step with:

```
/root/nimbus-eth2/beacon_chain/nimbus_binary_common.nim:84:15: internal compiler error: Segmentation fault
   84 | proc writePanicLine*(v: varargs[string, `$`]) =
      |               ^
0xf1206f diagnostic_context::diagnostic_impl(rich_location*, diagnostic_metadata const*, diagnostic_option_id, char const*, std::__va_list*, diagnostic_t)
0xee3693 internal_error(char const*, ...)
0x124b88f update_ssa(unsigned int)
Please submit a full bug report, with preprocessed source (by using -freport-bug).
See <file:///usr/share/doc/gcc-15/README.Bugs> for instructions.
make[2]: *** [/tmp/ccQIAbR7.mk:146: /tmp/ccJGPn5p.ltrans72.ltrans.o] Error 1
lto-wrapper: fatal error: make returned 2 exit status
compilation terminated.
/usr/bin/aarch64-linux-gnu-ld.bfd: error: lto-wrapper failed
collect2: error: ld returned 1 exit status
make[1]: *** [nimcache/release/nimbus_validator_client/nimbus_validator_client.makefile:2348: build] Error 1
make: *** [Makefile:449: nimbus_validator_client] Error 2
```

It's a segfault inside GCC's `update_ssa` during LTO on the C code Nim generates for the `writePanicLine` varargs proc. Not Nim's fault — a real GCC 15 bug. Pinning to `debian:trixie-slim` (gcc 14.2.0) sidesteps it and also makes the base image reproducible across rebuilds (testing rolls silently).

Both Linux AMD64 and ARM64 builds are affected (the arm64 cross-toolchain hits the same ICE).

### Reproduction

Every scheduled nimbus-eth2 image build in [ethpandaops/eth-client-docker-image-builder](https://github.com/ethpandaops/eth-client-docker-image-builder) is failing on this. Example failing job:

https://github.com/ethpandaops/eth-client-docker-image-builder/actions/runs/24721350367/job/72310899941

### ca-certificates

Also folds in what #8167 tried to fix — `debian:{testing,trixie}-slim` does not preinstall `ca-certificates`, so HTTPS submodule clones in `make update` can fail with `Problem with the SSL CA cert (path? access rights?)` depending on how the image was built. (That PR was auto-closed because it targeted `stable`; this one targets `unstable`.)

## Diff

\`\`\`diff
-FROM debian:testing-slim AS build
+FROM debian:trixie-slim AS build
-  && apt -y install build-essential git-lfs
+  && apt -y install build-essential git-lfs ca-certificates
-FROM debian:testing-slim as deploy
+FROM debian:trixie-slim as deploy
\`\`\`

## Test plan

- [x] Verified `debian:trixie-slim` ships `gcc-14` (14.2.0) via `apt -s install`, avoiding the GCC 15 ICE
- [ ] CI on this PR