### PR TITLE
Add config option for controlling LC data backfill

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -505,7 +505,8 @@ proc new*(T: type BeaconChainDBV0,
 
 proc new*(T: type BeaconChainDB,
           db: SqStoreRef,
-          cfg: RuntimeConfig
+          cfg: RuntimeConfig,
+          lightClientDataImportBackfill: bool
     ): BeaconChainDB =
   if not db.readOnly:
     # Remove the deposits table we used before we switched
@@ -679,7 +680,8 @@ proc new*(T: type BeaconChainDB,
           dir: string,
           cfg: RuntimeConfig,
           inMemory = false,
-          readOnly = false
+          readOnly = false,
+          lightClientDataImportBackfill = false
     ): BeaconChainDB =
   let db =
     if inMemory:
@@ -694,7 +696,7 @@ proc new*(T: type BeaconChainDB,
 
       SqStoreRef.init(
         dir, "nbc", readOnly = readOnly, manualCheckpoint = true).expectDb()
-  BeaconChainDB.new(db, cfg)
+  BeaconChainDB.new(db, cfg, lightClientDataImportBackfill)
 
 template getQuarantineDB*(db: BeaconChainDB): QuarantineDB =
   db.quarantine

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -506,7 +506,7 @@ proc new*(T: type BeaconChainDBV0,
 proc new*(T: type BeaconChainDB,
           db: SqStoreRef,
           cfg: RuntimeConfig,
-          lightClientDataImportBackfill: bool
+          lightClientDataImportBackfill = false
     ): BeaconChainDB =
   if not db.readOnly:
     # Remove the deposits table we used before we switched

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -554,6 +554,12 @@ type
         defaultValueDesc: $LightClientDataImportMode.OnlyNew
         name: "light-client-data-import-mode" .}: LightClientDataImportMode
 
+      lightClientDataImportBackfill* {.
+        hidden
+        desc: "Collect additional data for enabling peers to backfill light client data (experimental)"
+        defaultValue: false
+        name: "debug-light-client-data-import-backfill" .}: bool
+
       lightClientDataMaxPeriods* {.
         desc: "Maximum number of sync committee periods to retain light client data"
         name: "light-client-data-max-periods" .}: Option[uint64]

--- a/beacon_chain/consensus_object_pools/block_pools_types_light_client.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types_light_client.nim
@@ -62,6 +62,8 @@ type
       ## Whether to make local light client data available or not
     importMode*: LightClientDataImportMode
       ## Which classes of light client data to import
+    importBackfill*: bool
+      ## Whether to collect data for backfilling historical light client data
     maxPeriods*: Option[uint64]
       ## Maximum number of sync committee periods to retain light client data
     onLightClientFinalityUpdate*: OnLightClientFinalityUpdateCallback
@@ -85,6 +87,8 @@ type
       ## Whether to make local light client data available or not
     importMode*: LightClientDataImportMode
       ## Which classes of light client data to import
+    importBackfill*: bool
+      ## Whether to collect data for backfilling historical light client data
     maxPeriods*: uint64
       ## Maximum number of sync committee periods to retain light client data
 

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -110,6 +110,7 @@ proc initLightClientDataStore*(
     db: db,
     serve: config.serve,
     importMode: config.importMode,
+    importBackfill: config.importBackfill,
     maxPeriods: maxPeriods,
     onLightClientFinalityUpdate: config.onLightClientFinalityUpdate,
     onLightClientOptimisticUpdate: config.onLightClientOptimisticUpdate)

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -154,7 +154,9 @@ proc setupDatabase(
 ): Future[Opt[BeaconChainDB]] {.async: (raises: [CancelledError]).} =
   # Open the database and initialize it with genesis/checkpoint if it wasn't
   # setup before - fails if the data sources we use are broken
-  let db = BeaconChainDB.new(config.databaseDir, metadata.cfg, inMemory = false)
+  let db = BeaconChainDB.new(
+    config.databaseDir, metadata.cfg, inMemory = false,
+    lightClientDataImportBackfill = config.lightClientDataImportBackfill)
 
   if ChainDAGRef.isInitialized(db).isOk():
     if config.finalizedCheckpointState.isSome:
@@ -398,6 +400,7 @@ proc loadChainDag(
     lcDataConfig = LightClientDataConfig(
       serve: config.lightClientDataServe,
       importMode: config.lightClientDataImportMode,
+      importBackfill: config.lightClientDataImportBackfill,
       maxPeriods: config.lightClientDataMaxPeriods,
       onLightClientFinalityUpdate: onLightClientFinalityUpdateCb,
       onLightClientOptimisticUpdate: onLightClientOptimisticUpdateCb))
@@ -2943,7 +2946,9 @@ proc handleStartUpCmd(config: var BeaconNodeConf) {.raises: [CatchableError].} =
 
     let
       metadata = loadEth2Network(config)
-      db = BeaconChainDB.new(config.databaseDir, metadata.cfg, inMemory = false)
+      db = BeaconChainDB.new(
+        config.databaseDir, metadata.cfg, inMemory = false,
+        lightClientDataImportBackfill = config.lightClientDataImportBackfill)
       genesisState = (waitFor fetchGenesisState(metadata, config.eraDir)).valueOr:
         quit 1
     waitFor db.doRunTrustedNodeSync(

--- a/tests/consensus_spec/test_fixture_light_client_data_collection.nim
+++ b/tests/consensus_spec/test_fixture_light_client_data_collection.nim
@@ -141,7 +141,8 @@ proc runTest(suiteName, path: string, consensusFork: static ConsensusFork) =
       validatorMonitor = newClone(ValidatorMonitor.init(cfg))
       dag = ChainDAGRef.init(cfg, db, validatorMonitor, {},
         lcDataConfig = LightClientDataConfig(
-          serve: true, importMode: LightClientDataImportMode.Full))
+          serve: true, importMode: LightClientDataImportMode.Full,
+          importBackfill: true))
       rng = HmacDrbgContext.new()
       taskpool = Taskpool.new()
     var

--- a/tests/test_light_client.nim
+++ b/tests/test_light_client.nim
@@ -84,7 +84,8 @@ suite "Light client" & preset():
         cfg, cfg.makeTestDB(numValidators), validatorMonitor, {},
         lcDataConfig = LightClientDataConfig(
           serve: true,
-          importMode: LightClientDataImportMode.OnlyNew))
+          importMode: LightClientDataImportMode.OnlyNew,
+          importBackfill: true))
       quarantine = newClone(Quarantine.init(cfg))
       rng = HmacDrbgContext.new()
       taskpool = Taskpool.new()
@@ -238,13 +239,14 @@ suite "Light client" & preset():
         let finalizedSlot = (epoch + 2).start_slot
         dag.advanceToSlot(finalizedSlot, verifier, quarantine[])
 
-        let cpDb = BeaconChainDB.new("", cfg, inMemory = true)
+        let cpDb = BeaconChainDB.new(
+          "", cfg, inMemory = true, lightClientDataImportBackfill = true)
         ChainDAGRef.preInit(cpDb, genesisState[])
         ChainDAGRef.preInit(cpDb, dag.headState)
         let cpDag = ChainDAGRef.init(
           cfg, cpDb, validatorMonitor, {},
           lcDataConfig = LightClientDataConfig(
-            serve: true, importMode: importMode))
+            serve: true, importMode: importMode, importBackfill: true))
 
         for i in 1'u64 .. 10:
           let headSlot = (finalizedSlot.epoch + i).start_slot

--- a/tests/test_light_client_processor.nim
+++ b/tests/test_light_client_processor.nim
@@ -46,7 +46,8 @@ suite "Light client processor" & preset():
       cfg, cfg.makeTestDB(numValidators), validatorMonitor, {},
       lcDataConfig = LightClientDataConfig(
         serve: true,
-        importMode: LightClientDataImportMode.OnlyNew))
+        importMode: LightClientDataImportMode.OnlyNew,
+        importBackfill: true))
     quarantine = newClone(Quarantine.init(dag.cfg))
     rng = HmacDrbgContext.new()
     taskpool = Taskpool.new()

--- a/tests/testdbutil.nim
+++ b/tests/testdbutil.nim
@@ -20,7 +20,8 @@ export beacon_chain_db, testblockutil, kvstore, kvstore_sqlite3
 proc makeTestDB*(
     cfg: RuntimeConfig,
     validators: Natural,
-    eth1Data = Opt.none(Eth1Data)): BeaconChainDB =
+    eth1Data = Opt.none(Eth1Data),
+    lightClientDataImportBackfill = true): BeaconChainDB =
   # Blob support requires DENEB_FORK_EPOCH != FAR_FUTURE_EPOCH
   # Data column support requires GLOAS_FORK_EPOCH != FAR_FUTURE_EPOCH
   var cfg = cfg
@@ -44,7 +45,9 @@ proc makeTestDB*(
       forkyState.data.eth1_data = eth1Data.get
       forkyState.root = hash_tree_root(forkyState.data)
 
-  result = BeaconChainDB.new("", cfg, inMemory = true)
+  result = BeaconChainDB.new(
+    "", cfg, inMemory = true,
+    lightClientDataImportBackfill = lightClientDataImportBackfill)
   ChainDAGRef.preInit(result, genState[])
 
 proc getEarliestInvalidBlockRoot*(


### PR DESCRIPTION
This PR repeatedly gets quoted to point to LC data backfill resources, but on its own solely adds a config option.

⚠️ **The latest draft can be found at**: https://hackmd.io/@etan-status/decentralized-cl-sync

Original PR description below:

-----

As a first step towards enabling peers to backfill historical LC data in a trust-minimized way, add a debug flag that toggles activation, default off for any user-facing instantiations, and default on for all tests.

The eventual protocol will involve these steps:

1. Sync a LightClientStore (either light client or full node)
2. When period P+1 finalizes, fetch LightClientPeriodData for P, with:
   - first_header: BeaconBlockHeader corresponding to block_roots[0]
   - finality_transition_pre: Last block with finalized cp pre P start, block_roots[8191] if did not finalize during P, default for genesis (header, finalized_checkpoint, finality_branch)
   - finality_transition_post: First block with finalized cp in P, has finality_transition_pre as parent (or 0 if genesis as parent), default if finality_transition_pre is block_roots[8191] (header, finalized_checkpoint, finality_branch)
   - block_roots: All block_roots of P
   - current_sync_committee: Sync committee for P (if post-altair)
   - current_sync_committee_branch: Proof relative to state_roots[8191]
   - latest_state_root: state_root after slot 8191 into P
   - latest_state_root_branch: Proof relative to htr(state_roots)
   - historical_summary_branch: HistoricalSummary can be recovered from block_roots + latest_state_root + latest_state_root_branch. This proofs htr(HistoricalSummary) relative to anchor_update.header.
   - anchor_update: Reduced LightClientOptimisticUpdate version of best known LightClientUpdate for P+x with x >= 1 but as small as possible, makes it canonical
3. Assumption, client has full knowledge of periods > P from backfill or from local full node import. Verify optimistic_update is best, if P+1 is final, alternatively have to re-fetch later for canonical best
4. Fetch LightClientBlockData for post-altair epochs in P, with:
   - slot: Slot within P for this chunk, see block_roots[s % 8192]
   - sync_committee_bits: Part of the BeaconBlockBody
   - sync_committee_bits_branch: Proof relative to block_roots[s % 8192]
5. Verify answer is exhaustive (nothing withheld). For initial epoch, consult first_header from skeleton to see if it is in period < P and expected to be withheld when requesting P data
6. We can now run is_better_update from spec with LightClientBlockData and finality_transition_pre/post to identify canonical best update
7. Use light_client_updates_by_range/1 to obtain update for P, verify that it is canonical best. We can seal it, it cannot improve
8. Fetch LightClientBootstrapData for period P, response is list of:
   - header: LightClientHeader corresponding to block_roots[epoch_start] which may be in period < P, so cannot be bundled with the LightClientBlockData (only contains epochs in P, maybe newer fork)
   - current_sync_committee_branch: Proof of current_sync_committee in LightClientPeriodData relative to header.beacon.state_root
9. This reconstructs all LightClientBootstrap within period P, allowing peers to initiate sync from any historical checkpoint

Step 4-6 could be skipped by enshrining is_better_update into the STF, would also reduce block_roots need to just the epoch transition blocks with proofs relative to htr(block_roots). If proposed protocol becomes too complex / too heavy, could try revive it, but not needed for now.

- https://github.com/ethereum/consensus-specs/pull/3614