### PR TITLE
Use EL and CL identifiers in default graffiti

### DIFF
--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -117,10 +117,6 @@ type
     clientVersion: Opt[ClientVersionV1]
       ## The version reported through `engine_getClientVersionV1`.
 
-    clientVersionExchanged: bool
-      ## Whether `engine_getClientVersionV1` has been attempted for this
-      ## connection.
-
     state: ELConnectionState
     hysteresisCounter: int
 
@@ -300,16 +296,20 @@ proc connectedRpcClient(connection: ELConnection): Future[RpcClient] {.
   connection.web3.get.provider
 
 func consensusClientVersion(): ClientVersionV1 =
+  const commit = Bytes4(hexToByteArray[4](gitRevisionBytes4))
+
   ClientVersionV1(
-    code: "NB", name: "Nimbus", version: "v" & versionAsStr, commit: default(Bytes4)
+    code: "NB", name: "Nimbus", version: "v" & versionAsStr, commit: commit
   )
 
 func makeClientVersionGraffiti*(elVersion: ClientVersionV1): GraffitiBytes =
   let
     elCommit = toHex(distinctBase(elVersion.commit))
-    graffiti = elVersion.code & elCommit[0 ..< 4] & "NB" & gitRevision[0 ..< 4]
+    graffiti = elVersion.code & elCommit[0 ..< 4] & "NB" & gitRevisionBytes4[0 ..< 4]
 
-  distinctBase(result)[0 ..< graffiti.len] = toBytes(graffiti)
+  var res: GraffitiBytes
+  distinctBase(res)[0 ..< graffiti.len] = toBytes(graffiti)
+  res
 
 func getClientVersion*(m: ELManager): Opt[ClientVersionV1] =
   for connection in m.elConnections:
@@ -1106,8 +1106,7 @@ proc checkChainId(
 ) {.async: (raises: [CancelledError]).} =
   let rpcClient = await connection.connectedRpcClient()
 
-  if not connection.clientVersionExchanged:
-    connection.clientVersionExchanged = true
+  if connection.clientVersion.isNone:
     try:
       let versions = await connection.engineApiRequest(
         rpcClient.getClientVersion(consensusClientVersion()),
@@ -1124,7 +1123,6 @@ proc checkChainId(
           version = versions[0].version
     except CancelledError as exc:
       debug "Client version exchange was interrupted"
-      connection.clientVersionExchanged = false
       raise exc
     except CatchableError as exc:
       debug "Failed to obtain EL client version", reason = exc.msg

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -16,10 +16,11 @@ import
   eth/common/eth_types,
   results,
   kzg4844/[kzg_abi, kzg],
-  stew/objects,
+  stew/[byteutils, objects],
   # Local modules:
   ../spec/[engine_authentication, forks, helpers_el],
   ../networking/network_metadata,
+  ../version,
   "."/[el_conf, engine_api_conversions]
 
 from std/sequtils import anyIt, filterIt, mapIt
@@ -112,6 +113,13 @@ type
 
     chainIdStatus: ChainIdStatus
       ## The latest status of the `checkChainId` exchange.
+
+    clientVersion: Opt[ClientVersionV1]
+      ## The version reported through `engine_getClientVersionV1`.
+
+    clientVersionExchanged: bool
+      ## Whether `engine_getClientVersionV1` has been attempted for this
+      ## connection.
 
     state: ELConnectionState
     hysteresisCounter: int
@@ -290,6 +298,25 @@ proc connectedRpcClient(connection: ELConnection): Future[RpcClient] {.
       await sleepAsync(chronos.seconds(10))
 
   connection.web3.get.provider
+
+func consensusClientVersion(): ClientVersionV1 =
+  ClientVersionV1(
+    code: "NB", name: "Nimbus", version: "v" & versionAsStr, commit: default(Bytes4)
+  )
+
+func makeClientVersionGraffiti*(elVersion: ClientVersionV1): GraffitiBytes =
+  let
+    elCommit = toHex(distinctBase(elVersion.commit))
+    graffiti = elVersion.code & elCommit[0 ..< 4] & "NB" & gitRevision[0 ..< 4]
+
+  distinctBase(result)[0 ..< graffiti.len] = toBytes(graffiti)
+
+func getClientVersion*(m: ELManager): Opt[ClientVersionV1] =
+  for connection in m.elConnections:
+    if connection.clientVersion.isSome:
+      return connection.clientVersion
+
+  Opt.none(ClientVersionV1)
 
 template retryUntilCancelled(body: untyped) =
   ## Perform the same request in a loop until it is explicitly cancelled,
@@ -1078,6 +1105,29 @@ proc checkChainId(
     connection: ELConnection
 ) {.async: (raises: [CancelledError]).} =
   let rpcClient = await connection.connectedRpcClient()
+
+  if not connection.clientVersionExchanged:
+    connection.clientVersionExchanged = true
+    try:
+      let versions = await connection.engineApiRequest(
+        rpcClient.getClientVersion(consensusClientVersion()),
+        "getClientVersion",
+        Moment.now(),
+      )
+
+      if versions.len > 0:
+        connection.clientVersion = Opt.some(versions[0])
+        debug "Exchanged EL client version",
+          url = connection.engineUrl,
+          code = versions[0].code,
+          name = versions[0].name,
+          version = versions[0].version
+    except CancelledError as exc:
+      debug "Client version exchange was interrupted"
+      connection.clientVersionExchanged = false
+      raise exc
+    except CatchableError as exc:
+      debug "Failed to obtain EL client version", reason = exc.msg
 
   if m.eth1Network.isSome and
      connection.chainIdStatus == ChainIdStatus.notExchangedYet:

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -210,10 +210,18 @@ proc getValidatorForDuties*(
   node.attachedValidators[].getValidatorForDuties(
     key.toPubKey(), slot, slashingSafe)
 
-proc getGraffitiBytes*(
-    node: BeaconNode, validator: AttachedValidator): GraffitiBytes =
-  getGraffiti(node.config.validatorsDir, node.config.defaultGraffitiBytes(),
-              validator.pubkey)
+proc getGraffitiBytes*(node: BeaconNode, validator: AttachedValidator): GraffitiBytes =
+  let defaultGraffiti =
+    if node.config.graffiti.isSome:
+      node.config.defaultGraffitiBytes()
+    else:
+      let elClientVersion = node.elManager.getClientVersion()
+      if elClientVersion.isSome:
+        makeClientVersionGraffiti(elClientVersion.get)
+      else:
+        node.config.defaultGraffitiBytes()
+
+  getGraffiti(node.config.validatorsDir, defaultGraffiti, validator.pubkey)
 
 proc isSynced*(node: BeaconNode, head: BlockRef): bool =
   ## TODO This function is here as a placeholder for some better heurestics to

--- a/beacon_chain/version.nim
+++ b/beacon_chain/version.nim
@@ -20,7 +20,9 @@ const
   versionBlob* = "stateofus" # Single word - ends up in the default graffiti
 
   sourcePath = currentSourcePath.rsplit({DirSep, AltSep}, 1)[0]
-  gitRevision* = strip(generateGitRevision(sourcePath))[0..5]
+  sourceRevision = strip(generateGitRevision(sourcePath))
+  gitRevisionBytes4* = sourceRevision[0..7]
+  gitRevision* = sourceRevision[0..5]
 
   versionAsStr* =
     $versionMajor & "." & $versionMinor & "." & $versionBuild

--- a/tests/test_el_manager.nim
+++ b/tests/test_el_manager.nim
@@ -18,6 +18,7 @@ import
   eth/common/eth_types,
   ../beacon_chain/el/[el_conf, el_manager],
   ../beacon_chain/spec/[digest, engine_authentication, forks],
+  ../beacon_chain/version,
   ../beacon_chain/networking/network_metadata,
   ./testutil
 
@@ -37,20 +38,23 @@ type
     ## Tracks the state of a mock execution client for testing scenarios, mainly
     ## for the purpose of testing failure, timeout and error scenarios (rather
     ## than specific payload properties)
-    chainId: UInt256
-    shouldFailNewPayload: bool
-    shouldFailForkchoice: bool
-    shouldFailGetPayload: bool
-    shouldFailChainId: bool
-    newPayloadCallCount: int
-    newPayloadV5CallCount: int
-    forkchoiceCallCount: int
-    forkchoiceV4CallCount: int
-    getPayloadCallCount: int
-    getPayloadV6CallCount: int
-    chainIdCallCount: int
-    responseDelay: Duration
-    blockNumber: uint64
+    chainId*: UInt256
+    shouldFailNewPayload*: bool
+    shouldFailForkchoice*: bool
+    shouldFailGetPayload*: bool
+    shouldFailChainId*: bool
+    shouldFailClientVersion*: bool
+    newPayloadCallCount*: int
+    newPayloadV5CallCount*: int
+    forkchoiceCallCount*: int
+    forkchoiceV4CallCount*: int
+    getPayloadCallCount*: int
+    getPayloadV6CallCount*: int
+    chainIdCallCount*: int
+    getClientVersionCallCount*: int
+    clientVersion*: ClientVersionV1
+    responseDelay*: Duration
+    blockNumber*: uint64
 
   MockSetup = ref object
     state: MockEngineState
@@ -67,6 +71,7 @@ func createMockEngineState(
     shouldFailForkchoice: false,
     shouldFailGetPayload: false,
     shouldFailChainId: false,
+    shouldFailClientVersion: false,
     newPayloadCallCount: 0,
     newPayloadV5CallCount: 0,
     getPayloadCallCount: 0,
@@ -74,6 +79,13 @@ func createMockEngineState(
     forkchoiceCallCount: 0,
     forkchoiceV4CallCount: 0,
     chainIdCallCount: 0,
+    getClientVersionCallCount: 0,
+    clientVersion: ClientVersionV1(
+      code: "GE",
+      name: "go-ethereum",
+      version: "v1.14.0",
+      commit: Bytes4([0x16'u8, 0x8d, 0xbe, 0xef]),
+    ),
     responseDelay: 0.milliseconds,
     blockNumber: initialBlockNumber,
   )
@@ -198,7 +210,21 @@ func setupMockEngineAPI(server: RpcServer, state: MockEngineState) =
 
     state.chainId
 
-proc newMockRpcServer(
+  server.rpc("engine_getClientVersionV1", EthJson) do(
+    version: ClientVersionV1
+  ) -> seq[ClientVersionV1]:
+    inc state.getClientVersionCallCount
+    if state.responseDelay > 0.milliseconds:
+      await sleepAsync(state.responseDelay)
+
+    if state.shouldFailClientVersion:
+      raise (ref ApplicationError)(
+        code: -32603, msg: "Internal error: client version query failed"
+      )
+
+    return @[state.clientVersion]
+
+proc newMockRpcServer*(
     state: MockEngineState, port: Port
 ): RpcHttpServer {.raises: [CatchableError].} =
   ## Create and start a new mock RPC server on the given port
@@ -350,10 +376,44 @@ suite "EL Manager - Helpers":
 
       gethWsUrl == "ws://localhost:8545"
 
-func createELManager(
+  test "client version graffiti includes EL and CL versions":
+    let graffiti = makeClientVersionGraffiti(
+      ClientVersionV1(
+        code: "GE",
+        name: "go-ethereum",
+        version: "v1.14.0",
+        commit: Bytes4([0x16'u8, 0x8d, 0xbe, 0xef]),
+      )
+    )
+
+    check $graffiti == "GE168dNB" & gitRevision[0 ..< 4]
+
+  test "client version graffiti ignores long semver versions":
+    let graffiti = makeClientVersionGraffiti(
+      ClientVersionV1(
+        code: "GE",
+        name: "go-ethereum",
+        version: "v1.14.0-super-long-version-string",
+        commit: Bytes4([0x16'u8, 0x8d, 0xbe, 0xef]),
+      )
+    )
+
+    check $graffiti == "GE168dNB" & gitRevision[0 ..< 4]
+
+proc createELManager*(
     engines: seq[EngineApiUrl], eth1Network: Opt[Eth1Network] = Opt.none(Eth1Network)
 ): ELManager =
   ELManager.new(engines, eth1Network)
+
+proc waitForGetClientVersionRequest(
+    state: MockEngineState
+): Future[bool] {.async: (raises: [CancelledError]).} =
+  for _ in 0 ..< 50:
+    if state.getClientVersionCallCount > 0:
+      return true
+    await sleepAsync(50.milliseconds)
+
+  false
 
 suite "EL Manager - Async Operations":
   setup:
@@ -382,6 +442,32 @@ suite "EL Manager - Async Operations":
     manager.start()
 
     check manager.hasConnection()
+
+  test "ELManager exchanges client version":
+    let engineUrl = createEngineApiUrl(mockPort)
+    let manager = createELManager(@[engineUrl])
+    manager.start()
+
+    check waitFor waitForGetClientVersionRequest(mockState)
+
+    let version = manager.getClientVersion()
+    check:
+      mockState.getClientVersionCallCount == 1
+      version.isSome
+      version.get.code == "GE"
+      version.get.version == "v1.14.0"
+
+  test "ELManager ignores failed client version exchange":
+    mockState.shouldFailClientVersion = true
+    let engineUrl = createEngineApiUrl(mockPort)
+    let manager = createELManager(@[engineUrl])
+    manager.start()
+
+    check waitFor waitForGetClientVersionRequest(mockState)
+
+    check:
+      mockState.getClientVersionCallCount == 1
+      manager.getClientVersion().isNone
 
 suite "EL Manager - forkchoiceUpdated":
   setup:

--- a/tests/test_el_manager.nim
+++ b/tests/test_el_manager.nim
@@ -38,23 +38,23 @@ type
     ## Tracks the state of a mock execution client for testing scenarios, mainly
     ## for the purpose of testing failure, timeout and error scenarios (rather
     ## than specific payload properties)
-    chainId*: UInt256
-    shouldFailNewPayload*: bool
-    shouldFailForkchoice*: bool
-    shouldFailGetPayload*: bool
-    shouldFailChainId*: bool
-    shouldFailClientVersion*: bool
-    newPayloadCallCount*: int
-    newPayloadV5CallCount*: int
-    forkchoiceCallCount*: int
-    forkchoiceV4CallCount*: int
-    getPayloadCallCount*: int
-    getPayloadV6CallCount*: int
-    chainIdCallCount*: int
-    getClientVersionCallCount*: int
-    clientVersion*: ClientVersionV1
-    responseDelay*: Duration
-    blockNumber*: uint64
+    chainId: UInt256
+    shouldFailNewPayload: bool
+    shouldFailForkchoice: bool
+    shouldFailGetPayload: bool
+    shouldFailChainId: bool
+    shouldFailClientVersion: bool
+    newPayloadCallCount: int
+    newPayloadV5CallCount: int
+    forkchoiceCallCount: int
+    forkchoiceV4CallCount: int
+    getPayloadCallCount: int
+    getPayloadV6CallCount: int
+    chainIdCallCount: int
+    getClientVersionCallCount: int
+    clientVersion: ClientVersionV1
+    responseDelay: Duration
+    blockNumber: uint64
 
   MockSetup = ref object
     state: MockEngineState
@@ -224,7 +224,7 @@ func setupMockEngineAPI(server: RpcServer, state: MockEngineState) =
 
     return @[state.clientVersion]
 
-proc newMockRpcServer*(
+proc newMockRpcServer(
     state: MockEngineState, port: Port
 ): RpcHttpServer {.raises: [CatchableError].} =
   ## Create and start a new mock RPC server on the given port
@@ -386,7 +386,7 @@ suite "EL Manager - Helpers":
       )
     )
 
-    check $graffiti == "GE168dNB" & gitRevision[0 ..< 4]
+    check $graffiti == "GE168dNB" & gitRevisionBytes4[0 ..< 4]
 
   test "client version graffiti ignores long semver versions":
     let graffiti = makeClientVersionGraffiti(
@@ -398,9 +398,9 @@ suite "EL Manager - Helpers":
       )
     )
 
-    check $graffiti == "GE168dNB" & gitRevision[0 ..< 4]
+    check $graffiti == "GE168dNB" & gitRevisionBytes4[0 ..< 4]
 
-proc createELManager*(
+proc createELManager(
     engines: seq[EngineApiUrl], eth1Network: Opt[Eth1Network] = Opt.none(Eth1Network)
 ): ELManager =
   ELManager.new(engines, eth1Network)
@@ -453,7 +453,6 @@ suite "EL Manager - Async Operations":
     let version = manager.getClientVersion()
     check:
       mockState.getClientVersionCallCount == 1
-      version.isSome
       version.get.code == "GE"
       version.get.version == "v1.14.0"
 
@@ -466,7 +465,7 @@ suite "EL Manager - Async Operations":
     check waitFor waitForGetClientVersionRequest(mockState)
 
     check:
-      mockState.getClientVersionCallCount == 1
+      mockState.getClientVersionCallCount >= 1
       manager.getClientVersion().isNone
 
 suite "EL Manager - forkchoiceUpdated":


### PR DESCRIPTION
Uses the EL and CL version to default graffiti to match the implementation with other CL clients

Resolves #7580 