### PR TITLE
Add version envelope to Gloas event stream events

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -63,7 +63,8 @@ type
     finalQueue*: AsyncEventQueue[FinalizationInfoObject]
     fastConfirmationQueue*: AsyncEventQueue[FastConfirmationInfoObject]
     payloadAttributesQueue*: AsyncEventQueue[EventPayloadAttributesObject]
-    proposerPreferencesQueue*: AsyncEventQueue[EventProposerPreferencesObject]
+    proposerPreferencesQueue*: AsyncEventQueue[
+      RestVersioned[SignedProposerPreferences]]
     reorgQueue*: AsyncEventQueue[ReorgInfoObject]
     contribQueue*: AsyncEventQueue[SignedContributionAndProof]
     finUpdateQueue*: AsyncEventQueue[
@@ -74,8 +75,10 @@ type
     execPayloadAddedQueue*: AsyncEventQueue[EventExecutionPayloadObject]
     execPayloadGossipAddedQueue*: AsyncEventQueue[EventExecutionPayloadGossipObject]
     execPayloadAvlQueue*: AsyncEventQueue[EventExecutionPayloadAvailableObject]
-    execPayloadBidQueue*: AsyncEventQueue[gloas.SignedExecutionPayloadBid]
-    payloadAttMsgQueue*: AsyncEventQueue[PayloadAttestationMessage]
+    execPayloadBidQueue*: AsyncEventQueue[
+      RestVersioned[gloas.SignedExecutionPayloadBid]]
+    payloadAttMsgQueue*: AsyncEventQueue[
+      RestVersioned[PayloadAttestationMessage]]
 
   BeaconNode* = ref object
     nickname*: string
@@ -214,7 +217,7 @@ func init*(T: type EventBus): T =
     payloadAttributesQueue:
       newAsyncEventQueue[EventPayloadAttributesObject](),
     proposerPreferencesQueue:
-      newAsyncEventQueue[EventProposerPreferencesObject](),
+      newAsyncEventQueue[RestVersioned[SignedProposerPreferences]](),
     reorgQueue:
       newAsyncEventQueue[ReorgInfoObject](),
     contribQueue:
@@ -232,7 +235,7 @@ func init*(T: type EventBus): T =
     execPayloadAvlQueue:
       newAsyncEventQueue[EventExecutionPayloadAvailableObject](),
     execPayloadBidQueue:
-      newAsyncEventQueue[gloas.SignedExecutionPayloadBid](),
+      newAsyncEventQueue[RestVersioned[gloas.SignedExecutionPayloadBid]](),
     payloadAttMsgQueue:
-      newAsyncEventQueue[PayloadAttestationMessage](),
+      newAsyncEventQueue[RestVersioned[PayloadAttestationMessage]](),
   )

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -446,9 +446,6 @@ type
     slot*: Slot
     block_root*: Eth2Digest
 
-  EventProposerPreferencesObject* = object
-    data*: SignedProposerPreferences
-
   RestPayloadAttributes* = object
     timestamp*: uint64
     prev_randao*: Eth2Digest

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -543,12 +543,23 @@ proc initFullNode(
     node.eventBus.execPayloadAvlQueue.emit(
       EventExecutionPayloadAvailableObject.init(data))
   proc onExecutionPayloadBidAdded(data: gloas.SignedExecutionPayloadBid) =
-    node.eventBus.execPayloadBidQueue.emit(data)
+    let epoch = data.message.slot.epoch
+    node.eventBus.execPayloadBidQueue.emit(
+      RestVersioned[gloas.SignedExecutionPayloadBid](
+        data: data,
+        jsonVersion: node.dag.cfg.consensusForkAtEpoch(epoch)))
   proc onPayloadAttestationMessageAdded(data: PayloadAttestationMessage) =
-    node.eventBus.payloadAttMsgQueue.emit(data)
+    let epoch = data.data.slot.epoch
+    node.eventBus.payloadAttMsgQueue.emit(
+      RestVersioned[PayloadAttestationMessage](
+        data: data,
+        jsonVersion: node.dag.cfg.consensusForkAtEpoch(epoch)))
   proc onProposerPreferencesAdded(data: SignedProposerPreferences) =
+    let epoch = data.message.proposal_slot.epoch
     node.eventBus.proposerPreferencesQueue.emit(
-      EventProposerPreferencesObject(data: data))
+      RestVersioned[SignedProposerPreferences](
+        data: data,
+        jsonVersion: node.dag.cfg.consensusForkAtEpoch(epoch)))
   proc makeOnFinalizationCb(
       # This `nimcall` functions helps for keeping track of what
       # needs to be captured by the onFinalization closure.

--- a/beacon_chain/spec/eth2_apis/eth2_rest_json_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_json_serialization.nim
@@ -94,7 +94,6 @@ RestJson.useDefaultSerializationFor(
   EventExecutionPayloadGossipObject,
   EventExecutionPayloadAvailableObject,
   EventPayloadAttributesObject,
-  EventProposerPreferencesObject,
   FastConfirmationInfoObject,
   FinalizationInfoObject,
   Fork,

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -142,6 +142,11 @@ type
     jsonVersion*: ConsensusFork
     sszContext*: ForkDigest
 
+  SomeVersionedEventObject* =
+    gloas.SignedExecutionPayloadBid |
+    PayloadAttestationMessage |
+    SignedProposerPreferences
+
   RestBlockTypes* = phase0.BeaconBlock | altair.BeaconBlock |
                     bellatrix.BeaconBlock | capella.BeaconBlock |
                     deneb.BlockContents | electra.BlockContents |
@@ -283,6 +288,13 @@ proc prepareJsonStringResponse*[T: SomeForkedLightClientObject](
           w.writeField("data", forkyObject)
     else:
       default(string)
+
+proc prepareJsonStringResponse*[T: SomeVersionedEventObject](
+    _: typedesc[RestApiResponse], d: RestVersioned[T]): string =
+  withRestJsonWriter(w, string):
+    w.writeObject:
+      w.writeField("version", d.jsonVersion.toString())
+      w.writeField("data", d.data)
 
 proc prepareJsonStringResponse*(_: typedesc[RestApiResponse], d: auto): string =
   RestJson.encode(d)


### PR DESCRIPTION
## Problem

Three Gloas event stream topics are specified to wrap their payload in a versioned envelope, but Nimbus emits the bare object:

| topic | Nimbus | spec |
|---|---|---|
| `execution_payload_bid` | `{"message":{...},"signature":"0x…"}` | `{"version":"gloas","data":{…}}` |
| `payload_attestation_message` | `{"validator_index":…,"data":{…},"signature":"0x…"}` | `{"version":"gloas","data":{…}}` |
| `proposer_preferences` | `{"data":{…}}` — no `version` | `{"version":"gloas","data":{…}}` |

Spec: [`apis/eventstream/index.yaml`](https://github.com/ethereum/beacon-APIs/blob/master/apis/eventstream/index.yaml).

Observed on `glamsterdam-devnet-7`. Lighthouse, Teku and Grandine all emit the specified form on the same network, so consumers reasonably assume the envelope is there. Dora, for example, fails every bid event with:

```
beacon block stream failed to decode execution_payload_bid event: unexpected end of JSON input
```

Its envelope unmarshal succeeds but yields a nil `data`, so the follow-up decode hits empty input.

## Cause

The generic `eventHandler` in `beacon_chain/rpc/rest_event_api.nim` calls `RestApiResponse.prepareJsonStringResponse(event)`. The only overload that writes `version` + `data` is constrained to `SomeForkedLightClientObject`; everything else falls through to `prepareJsonStringResponse(d: auto) = RestJson.encode(d)`.

The light client queues are declared as `AsyncEventQueue[RestVersioned[…]]` and so hit the versioned overload. `execPayloadBidQueue`, `payloadAttMsgQueue` and `proposerPreferencesQueue` hold raw types and lose the envelope.

## Fix

- Wrap the three queues in `RestVersioned[T]`, matching `finUpdateQueue` / `optUpdateQueue`.
- Add a `prepareJsonStringResponse` overload for a new `SomeVersionedEventObject` typeclass covering the three payload types. It is disjoint from `SomeForkedLightClientObject`, so no overload ambiguity.
- Derive `jsonVersion` / `sszContext` from the relevant slot (bid `message.slot`, payload attestation `data.slot`, `message.proposal_slot`) via `consensusForkAtEpoch` / `forkDigestAtEpoch` rather than hardcoding `gloas`.
- Drop `EventProposerPreferencesObject`, which existed only to produce `{"data":…}` and is superseded by `RestVersioned`.

No wire change for any other topic.

## Testing

Builds clean (`make nimbus_beacon_node`, binary reports `v26.7.0-9f2756` matching this commit).

Verified the emitted shape directly by serialising each of the three payload types through the new overload:

```
BID: {"version":"gloas","data":{"message":{"parent_block_hash":"0x00…","slot":"0",…},"signature":"0x00…"}}
PAM: {"version":"gloas","data":{"validator_index":"0","data":{"beacon_block_root":"0x00…",…},"signature":"0x00…"}}
PP:  {"version":"gloas","data":{"message":{"dependent_root":"0x00…","proposal_slot":"0",…},"signature":"0x00…"}}
```

All three now match the spec envelope. Expected shape cross-checked against Lighthouse/Teku/Grandine output on `glamsterdam-devnet-7`.
