### PR TITLE
fix(vc): ignore unscheduled fork timing skew across beacon nodes

### DIFF
--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -142,7 +142,8 @@ proc initTimeConfig(
           let timeParams = resp.data.data.getTimeParams()
           if timeParams.isSome:
             debug "Received time configuration parameters", endpoint = nodes[i],
-                  slot_duration_ms = timeParams.get.SLOT_DURATION.milliseconds
+                  slot_duration_ms = timeParams.get.SLOT_DURATION.milliseconds,
+                  payload_due_bps = timeParams.get.PAYLOAD_DUE_BPS
             if res.isNone:
               res = timeParams
             elif timeParams.get == res.get:
@@ -153,7 +154,9 @@ proc initTimeConfig(
                     slot_duration_ms =
                       timeParams.get.SLOT_DURATION.milliseconds,
                     expected_slot_duration_ms =
-                      res.get.SLOT_DURATION.milliseconds
+                      res.get.SLOT_DURATION.milliseconds,
+                    differences = describeTimeParamsDifferences(
+                      timeParams.get, res.get)
               didEncounterDisagreement = true
           else:
             debug "Received invalid time configuration parameters",

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -657,6 +657,63 @@ func checkConfig*(c: VCRuntimeConfig, timeParams: TimeParams): bool =
     timeParams.SLOT_DURATION == defaultRuntimeConfig.timeParams.SLOT_DURATION
   )
 
+func isForkScheduled*(
+    info: VCRuntimeConfig, consensusFork: ConsensusFork): bool =
+  ## Returns false when the fork epoch key is missing or FAR_FUTURE_EPOCH.
+  doAssert consensusFork > ConsensusFork.Phase0
+  let key = consensusFork.forkEpochConfigKey()
+  info.hasKey(key) and not info.equals(key, FAR_FUTURE_EPOCH)
+
+func canonicalizeTimeParams*(
+    timeParams: TimeParams, info: VCRuntimeConfig): TimeParams =
+  ## Replace timing fields that only apply to unscheduled forks with local
+  ## defaults. This keeps VC startup tolerant of draft-constant churn on
+  ## `/eth/v1/config/spec` while Gloas/Heze remain FAR_FUTURE.
+  ## Once a fork is scheduled, those fields remain as reported by the BN and
+  ## must agree across beacon nodes.
+  var res = timeParams
+  if not info.isForkScheduled(ConsensusFork.Gloas):
+    res.ATTESTATION_DUE_BPS_GLOAS =
+      defaultRuntimeConfig.timeParams.ATTESTATION_DUE_BPS_GLOAS
+    res.AGGREGATE_DUE_BPS_GLOAS =
+      defaultRuntimeConfig.timeParams.AGGREGATE_DUE_BPS_GLOAS
+    res.SYNC_MESSAGE_DUE_BPS_GLOAS =
+      defaultRuntimeConfig.timeParams.SYNC_MESSAGE_DUE_BPS_GLOAS
+    res.CONTRIBUTION_DUE_BPS_GLOAS =
+      defaultRuntimeConfig.timeParams.CONTRIBUTION_DUE_BPS_GLOAS
+    res.PAYLOAD_DUE_BPS =
+      defaultRuntimeConfig.timeParams.PAYLOAD_DUE_BPS
+    res.PAYLOAD_ATTESTATION_DUE_BPS =
+      defaultRuntimeConfig.timeParams.PAYLOAD_ATTESTATION_DUE_BPS
+  if not info.isForkScheduled(ConsensusFork.Heze):
+    res.INCLUSION_LIST_DUE_BPS =
+      defaultRuntimeConfig.timeParams.INCLUSION_LIST_DUE_BPS
+  res
+
+func describeTimeParamsDifferences*(a, b: TimeParams): string =
+  ## Human-readable list of TimeParams fields that differ, for diagnostics.
+  var diffs: seq[string]
+  if a.SLOT_DURATION != b.SLOT_DURATION:
+    diffs.add(
+      "SLOT_DURATION_MS=" & $a.SLOT_DURATION.milliseconds &
+      "!=" & $b.SLOT_DURATION.milliseconds)
+  template check(fieldName: static string, field: untyped) =
+    if a.field != b.field:
+      diffs.add(fieldName & "=" & $a.field & "!=" & $b.field)
+  check("PROPOSER_REORG_CUTOFF_BPS", PROPOSER_REORG_CUTOFF_BPS)
+  check("ATTESTATION_DUE_BPS", ATTESTATION_DUE_BPS)
+  check("AGGREGATE_DUE_BPS", AGGREGATE_DUE_BPS)
+  check("SYNC_MESSAGE_DUE_BPS", SYNC_MESSAGE_DUE_BPS)
+  check("CONTRIBUTION_DUE_BPS", CONTRIBUTION_DUE_BPS)
+  check("ATTESTATION_DUE_BPS_GLOAS", ATTESTATION_DUE_BPS_GLOAS)
+  check("AGGREGATE_DUE_BPS_GLOAS", AGGREGATE_DUE_BPS_GLOAS)
+  check("SYNC_MESSAGE_DUE_BPS_GLOAS", SYNC_MESSAGE_DUE_BPS_GLOAS)
+  check("CONTRIBUTION_DUE_BPS_GLOAS", CONTRIBUTION_DUE_BPS_GLOAS)
+  check("PAYLOAD_DUE_BPS", PAYLOAD_DUE_BPS)
+  check("PAYLOAD_ATTESTATION_DUE_BPS", PAYLOAD_ATTESTATION_DUE_BPS)
+  check("INCLUSION_LIST_DUE_BPS", INCLUSION_LIST_DUE_BPS)
+  diffs.join(", ")
+
 func getTimeParams*(c: VCRuntimeConfig): Opt[TimeParams] =
   let SLOT_DURATION =
     if c.hasKey("SLOT_DURATION_MS"):
@@ -693,10 +750,11 @@ func getTimeParams*(c: VCRuntimeConfig): Opt[TimeParams] =
     SYNC_MESSAGE_DUE_BPS_GLOAS: parseBps "SYNC_MESSAGE_DUE_BPS_GLOAS",
     CONTRIBUTION_DUE_BPS_GLOAS: parseBps "CONTRIBUTION_DUE_BPS_GLOAS",
     PAYLOAD_DUE_BPS: parseBps "PAYLOAD_DUE_BPS",
-    PAYLOAD_ATTESTATION_DUE_BPS: parseBps "PAYLOAD_ATTESTATION_DUE_BPS")
+    PAYLOAD_ATTESTATION_DUE_BPS: parseBps "PAYLOAD_ATTESTATION_DUE_BPS",
+    INCLUSION_LIST_DUE_BPS: parseBps "INCLUSION_LIST_DUE_BPS")
   if not res.get.isValid:
     return Opt.none TimeParams
-  res
+  Opt.some res.get.canonicalizeTimeParams(c)
 
 proc updateStatus*(node: BeaconNodeServerRef,
                    status: RestBeaconNodeStatus,

--- a/tests/test_validator_client.nim
+++ b/tests/test_validator_client.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Copyright (c) 2018-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -1183,3 +1183,65 @@ suite "Validator Client test suite":
       len(res.get().data) == 1
       res.get().data[0].index == 100000
       res.get().data[0].is_live == true
+
+  test "getTimeParams() ignores unscheduled Gloas PAYLOAD_DUE_BPS skew":
+    # Beacon nodes on different Gloas draft constants (alpha.11 vs alpha.12)
+    # should still produce identical TimeParams while Gloas remains FAR_FUTURE.
+    # https://github.com/status-im/nimbus-eth2/issues/8833
+    proc baseConfig(payloadDueBps: string): VCRuntimeConfig =
+      result["SLOT_DURATION_MS"] = "12000"
+      result["SECONDS_PER_SLOT"] = "12"
+      result["PROPOSER_REORG_CUTOFF_BPS"] = "1667"
+      result["ATTESTATION_DUE_BPS"] = "3333"
+      result["AGGREGATE_DUE_BPS"] = "6667"
+      result["SYNC_MESSAGE_DUE_BPS"] = "3333"
+      result["CONTRIBUTION_DUE_BPS"] = "6667"
+      result["ATTESTATION_DUE_BPS_GLOAS"] = "2500"
+      result["AGGREGATE_DUE_BPS_GLOAS"] = "5000"
+      result["SYNC_MESSAGE_DUE_BPS_GLOAS"] = "2500"
+      result["CONTRIBUTION_DUE_BPS_GLOAS"] = "5000"
+      result["PAYLOAD_DUE_BPS"] = payloadDueBps
+      result["PAYLOAD_ATTESTATION_DUE_BPS"] = "7500"
+      result["INCLUSION_LIST_DUE_BPS"] = "6667"
+      result["GLOAS_FORK_EPOCH"] = Base10.toString(uint64(FAR_FUTURE_EPOCH))
+      result["HEZE_FORK_EPOCH"] = Base10.toString(uint64(FAR_FUTURE_EPOCH))
+
+    let
+      alpha11 = baseConfig("7500").getTimeParams()
+      alpha12 = baseConfig("5000").getTimeParams()
+    check:
+      alpha11.isSome()
+      alpha12.isSome()
+      alpha11.get() == alpha12.get()
+      alpha11.get().PAYLOAD_DUE_BPS ==
+        defaultRuntimeConfig.timeParams.PAYLOAD_DUE_BPS
+      describeTimeParamsDifferences(alpha11.get(), alpha12.get()).len == 0
+
+  test "getTimeParams() requires Gloas PAYLOAD_DUE_BPS agreement when scheduled":
+    proc scheduledConfig(payloadDueBps: string): VCRuntimeConfig =
+      result["SLOT_DURATION_MS"] = "12000"
+      result["SECONDS_PER_SLOT"] = "12"
+      result["PROPOSER_REORG_CUTOFF_BPS"] = "1667"
+      result["ATTESTATION_DUE_BPS"] = "3333"
+      result["AGGREGATE_DUE_BPS"] = "6667"
+      result["SYNC_MESSAGE_DUE_BPS"] = "3333"
+      result["CONTRIBUTION_DUE_BPS"] = "6667"
+      result["ATTESTATION_DUE_BPS_GLOAS"] = "2500"
+      result["AGGREGATE_DUE_BPS_GLOAS"] = "5000"
+      result["SYNC_MESSAGE_DUE_BPS_GLOAS"] = "2500"
+      result["CONTRIBUTION_DUE_BPS_GLOAS"] = "5000"
+      result["PAYLOAD_DUE_BPS"] = payloadDueBps
+      result["PAYLOAD_ATTESTATION_DUE_BPS"] = "7500"
+      result["INCLUSION_LIST_DUE_BPS"] = "6667"
+      # Any concrete epoch marks Gloas as scheduled for comparison purposes.
+      result["GLOAS_FORK_EPOCH"] = "1000000"
+      result["HEZE_FORK_EPOCH"] = Base10.toString(uint64(FAR_FUTURE_EPOCH))
+
+    let
+      a = scheduledConfig("7500").getTimeParams()
+      b = scheduledConfig("5000").getTimeParams()
+    check:
+      a.isSome()
+      b.isSome()
+      a.get() != b.get()
+      "PAYLOAD_DUE_BPS" in describeTimeParamsDifferences(a.get(), b.get())


### PR DESCRIPTION
## Summary
- Canonicalize Gloas/Heze-only `TimeParams` fields to local defaults when those forks are still `FAR_FUTURE`, so VC startup no longer fails if beacon nodes disagree on draft constants such as `PAYLOAD_DUE_BPS` (alpha.11 `7500` vs alpha.12 `5000`).
- Once a fork is scheduled, those fields still require cross-BN agreement.
- Improve the incompatible-time-config warning to log which `TimeParams` fields differ.
- Add unit coverage for the unscheduled vs scheduled comparison behavior.

Fixes #8833

## Motivation
Nimbus VC compares full `TimeParams` from every configured beacon node's `/eth/v1/config/spec` during `initTimeConfig()`. Gloas timing keys like `PAYLOAD_DUE_BPS` are already exposed before Gloas is scheduled, and clients currently ship different draft values. That causes multi-client VC setups (e.g. Nimbus/Teku, or Lodestar1.46-rc.0/Lighthouse/Grandine) to fail startup with `Could not obtain time configuration parameters`, even though runtime compatibility only checks slot duration.

## Test plan
- [x] Added unit tests in `tests/test_validator_client.nim` covering:
  - unscheduled Gloas: `PAYLOAD_DUE_BPS` 7500 vs 5000 canonicalizes to equal `TimeParams`
  - scheduled Gloas: same disagreement remains unequal and is described in the diff helper
- [ ] CI `test_validator_client` / unit suite
- [ ] Manual: VC with Lodestar (`PAYLOAD_DUE_BPS=5000`) + Lighthouse/Nimbus (`7500`) while `GLOAS_FORK_EPOCH` is far-future should start successfully

## AI assistance disclosure
I used Cursor (Composer) to help inspect the Nimbus VC startup path, draft this patch, and prepare the PR text. I reviewed the resulting diff and intend it as a proposed fix for #8833 / the Lodestar interop case discussed there. I'm a node operator rather than a regular Nimbus contributor, so corrections from maintainers are welcome.