### PR TITLE
Vendor: Use web3 with checked exceptions.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,7 +34,7 @@
 	path = vendor/nim-web3
 	url = https://github.com/status-im/nim-web3.git
 	ignore = untracked
-	branch = master
+	branch = feature/checked_exceptions
 [submodule "vendor/nim-nat-traversal"]
 	path = vendor/nim-nat-traversal
 	url = https://github.com/status-im/nim-nat-traversal.git


### PR DESCRIPTION
Testing that https://github.com/status-im/nim-web3/pull/259 doesn't break anything in a dependent package.