### PR TITLE
remove force build

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -77,7 +77,7 @@ if defined(limitStackUsage):
   # stack size of each function.
   switch("passC", "-fstack-usage -Werror=stack-usage=851968")
   switch("passL", "-fstack-usage -Werror=stack-usage=851968")
-  
+
   # QUIC does variable stack allocations
   put("lsquic_enc_sess_ietf.always", "-fno-lto -Wno-stack-usage")
   put("lsquic_handshake.always", "-fno-lto -Wno-stack-usage")
@@ -142,7 +142,6 @@ switch("passL", "-fno-omit-frame-pointer")
 --define:nimTypeNames
 
 switch("define", "nim_compiler_path=" & currentDir & "env.sh nim")
-switch("define", "withoutPCRE")
 
 when not defined(disable_libbacktrace):
   --define:nimStackTraceOverride

--- a/scripts/compile_nim_program.sh
+++ b/scripts/compile_nim_program.sh
@@ -9,8 +9,6 @@
 
 set -Eeo pipefail
 
-# cd "$(dirname "${BASH_SOURCE[0]}")"/..
-
 BINARY="$1"
 SOURCE="$2"
 # the rest are NIM_PARAMS

--- a/scripts/compile_nim_program.sh
+++ b/scripts/compile_nim_program.sh
@@ -9,7 +9,7 @@
 
 set -Eeo pipefail
 
-cd "$(dirname "${BASH_SOURCE[0]}")"/..
+# cd "$(dirname "${BASH_SOURCE[0]}")"/..
 
 BINARY="$1"
 SOURCE="$2"

--- a/scripts/compile_nim_program.sh
+++ b/scripts/compile_nim_program.sh
@@ -28,13 +28,7 @@ PROJECT_NAME="$(basename "${BINARY%.nim}")"
 # parallel.
 # We can't use '--nimcache:...' here, because the same path is being used by
 # LTO on macOS, in "config.nims"
-# We have to use the `-f` flag here because running nim compile with
-# different -d defines (as we do when for mainnet/minimal in CI) does
-# not lead to a rebuild of changed deps - nim uses the cached
-# version. The specific instance here is `-d:FIELD_ELEMENTS_PER_BLOB`
-# that is used in the nim-kzg library and its dependency.
-# TODO find a way not to have to -f here.
-"$NIMC" c -f --compileOnly -o:build/"${BINARY}" "$@" -d:nimCachePathOverride=nimcache/release/"${BINARY}" "${SOURCE}"
+"$NIMC" c --compileOnly -o:build/"${BINARY}" "$@" -d:nimCachePathOverride=nimcache/release/"${BINARY}" "${SOURCE}"
 build/generate_makefile "nimcache/release/${BINARY}/${PROJECT_NAME}.json" "nimcache/release/${BINARY}/${BINARY}.makefile"
 # Don't swallow stderr, in case it's important.
 [[ "$V" == "0" ]] && exec >/dev/null

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -688,7 +688,7 @@ done
 
 if [[ "${REUSE_BINARIES}" == "0" || "${BINARIES_MISSING}" == "1" ]]; then
   log "Rebuilding binaries ${BINARIES}"
-  ${MAKE} -j ${NPROC} LOG_LEVEL=TRACE NIMFLAGS="${NIMFLAGS}" -d:local_testnet -d:const_preset=${CONST_PRESET} ${BINARIES}
+  ${MAKE} -j ${NPROC} LOG_LEVEL=TRACE NIMFLAGS="${NIMFLAGS} -d:local_testnet -d:const_preset=${CONST_PRESET}" ${BINARIES}
 fi
 
 if [[ "${RUN_NIMBUS_ETH1}" == "1" ]]; then

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -688,7 +688,7 @@ done
 
 if [[ "${REUSE_BINARIES}" == "0" || "${BINARIES_MISSING}" == "1" ]]; then
   log "Rebuilding binaries ${BINARIES}"
-  ${MAKE} -j ${NPROC} LOG_LEVEL=TRACE NIMFLAGS="${NIMFLAGS} -d:local_testnet -d:const_preset=${CONST_PRESET} ${BINARIES}
+  ${MAKE} -j ${NPROC} LOG_LEVEL=TRACE NIMFLAGS="${NIMFLAGS}" -d:local_testnet -d:const_preset=${CONST_PRESET} ${BINARIES}
 fi
 
 if [[ "${RUN_NIMBUS_ETH1}" == "1" ]]; then

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -688,7 +688,7 @@ done
 
 if [[ "${REUSE_BINARIES}" == "0" || "${BINARIES_MISSING}" == "1" ]]; then
   log "Rebuilding binaries ${BINARIES}"
-  ${MAKE} -j ${NPROC} LOG_LEVEL=TRACE NIMFLAGS="${NIMFLAGS} -d:local_testnet -d:const_preset=${CONST_PRESET} -d:FIELD_ELEMENTS_PER_BLOB=4096" ${BINARIES}
+  ${MAKE} -j ${NPROC} LOG_LEVEL=TRACE NIMFLAGS="${NIMFLAGS} -d:local_testnet -d:const_preset=${CONST_PRESET} ${BINARIES}
 fi
 
 if [[ "${RUN_NIMBUS_ETH1}" == "1" ]]; then

--- a/tools/generate_makefile.nim
+++ b/tools/generate_makefile.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2020-2024 Status Research & Development GmbH
+# Copyright (c) 2020-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tools/generate_makefile.nim
+++ b/tools/generate_makefile.nim
@@ -7,11 +7,11 @@
 
 {.push raises: [].}
 
-# Generate a Makefile from the JSON file produce by the Nim compiler with
+# Generate a Makefile from the JSON file produced by the Nim compiler with
 # "--compileOnly". Suitable for Make-controlled parallelisation, down to the GCC
 # LTO level.
 
-import std/[json, os, strutils]
+import std/[cmdline, json, os, strutils]
 
 # Ripped off from Nim's `linkViaResponseFile()` in "compiler/extccomp.nim".
 # It lets us get around a command line length limit on Windows.
@@ -24,14 +24,17 @@ proc processLinkCmd(cmd, linkerArgs: string): string {.raises: [IOError].} =
 
   if cmd.len > 0 and cmd[0] == '"':
     inc i
-    while i < cmd.len and cmd[i] != '"': inc i
+    while i < cmd.len and cmd[i] != '"':
+      inc i
     last = i
     inc i
   else:
-    while i < cmd.len and cmd[i] != ' ': inc i
+    while i < cmd.len and cmd[i] != ' ':
+      inc i
     last = i
 
-  while i < cmd.len and cmd[i] == ' ': inc i
+  while i < cmd.len and cmd[i] == ' ':
+    inc i
 
   let args = cmd.substr(i)
   writeFile(linkerArgs, args.replace('\\', '/'))
@@ -74,63 +77,60 @@ proc main() =
     makefile.close()
 
   var
-    objectPath: string
-    found: bool
+    objects: seq[string]
     cmd: string
 
   try:
     try:
       for compile in data["compile"]:
         cmd = compile[1].getStr().replace('\\', '/')
-        objectPath = ""
-        found = false
-        for token in split(cmd, Whitespace + {'\''}):
-          if found and token.len > 0 and token.endsWith(".o"):
-            objectPath = token.replace('\\', '/')
+        var
+          next = false
+          found = false
+        for token in parseCmdLine(cmd):
+          if next:
+            if token.len > 0 and token.endsWith(".o"):
+              makefile.writeLine(token & ":")
+              makefile.writeLine("\t " & cmd)
+
+              objects.add token
+              found = true
             break
+
           if token == "-o":
-            found = true
-        if found == false or objectPath == "":
+            next = true
+
+        if not found:
           echo "Could not find the object file in this command: ", cmd
           quit(QuitFailure)
-        try:
-          makefile.writeLine(".PHONY: " & objectPath)
-          makefile.writeLine("$#: $#" % [
-            objectPath,
-            compile[0].getStr().replace('\\', '/')])
-          makefile.writeLine("\t+ $#\n" % cmd)
-        except ValueError:
-          # https://github.com/nim-lang/Nim/pull/23356
-          raiseAssert "Arguments match the format string"
     except KeyError:
       echo "File lacks `compile` key: ", jsonPath
       quit(QuitFailure)
 
-    var objects: seq[string]
-    try:
-      for obj in data["link"]:
-        objects.add(obj.getStr().replace('\\', '/'))
-    except KeyError:
-      echo "File lacks `link` key: ", jsonPath
-      quit(QuitFailure)
-    try:
-      makefile.writeLine("OBJECTS := $#\n" % objects.join(" \\\n"))
-    except ValueError:
-      # https://github.com/nim-lang/Nim/pull/23356
-      raiseAssert "Arguments match the format string"
 
-    makefile.writeLine(".PHONY: build")
+    makefile.writeLine("OBJECTS := " & objects.join(" \\\n"))
+
+    # The json instructions contain exactly the files that need to be rebuilt
+    # (ie source modified / flags changed etc) so we mark all objects PHONY to
+    # force them to be rebuilt
+    # TODO change detection does not deeply cover changes in C file includes etc
+    makefile.writeLine(".PHONY: build $(OBJECTS)")
     makefile.writeLine("build: $(OBJECTS)")
+
     let linkerArgs = makefilePath & ".linkerArgs"
     try:
-      makefile.writeLine("\t+ $#" % processLinkCmd(
-        data["linkcmd"].getStr().replace('\\', '/'), linkerArgs))
+      # + ensures the jobserver protocol is active in the linker command, for
+      # LTO + jobserver purposes
+      makefile.writeLine(
+        "\t+ " & processLinkCmd(data["linkcmd"].getStr().replace('\\', '/'), linkerArgs)
+      )
     except IOError as exc:
       echo "Failed to write file: ", linkerArgs, " - [IOError]: ", exc.msg
       quit(QuitFailure)
-    except ValueError:
-      # https://github.com/nim-lang/Nim/pull/23356
-      raiseAssert "Arguments match the format string"
+    except KeyError as exc:
+      echo "Missing linkcmd"
+      quit(QuitFailure)
+
     if data.hasKey("extraCmds"):
       try:
         for cmd in data["extraCmds"]:

--- a/tools/generate_makefile.nim
+++ b/tools/generate_makefile.nim
@@ -86,7 +86,7 @@ proc main() =
         found = false
         for token in split(cmd, Whitespace + {'\''}):
           if found and token.len > 0 and token.endsWith(".o"):
-            objectPath = token
+            objectPath = token.replace('\\', '/')
             break
           if token == "-o":
             found = true
@@ -94,8 +94,9 @@ proc main() =
           echo "Could not find the object file in this command: ", cmd
           quit(QuitFailure)
         try:
+          makefile.writeLine(".PHONY: " & objectPath)
           makefile.writeLine("$#: $#" % [
-            objectPath.replace('\\', '/'),
+            objectPath,
             compile[0].getStr().replace('\\', '/')])
           makefile.writeLine("\t+ $#\n" % cmd)
         except ValueError:


### PR DESCRIPTION
Cache includes command line in more recent nim versions, this Should Work™.

edit: this was probably a problem with the makefile generator - the makefile needs to rebuild *all* object files even if the object file is newer than the c file to make sure command-line-flag-based changes cause rebuilds.