### PR TITLE
pre-verify gloas builder deposits received before gloas fork

### DIFF
--- a/beacon_chain/deposits.nim
+++ b/beacon_chain/deposits.nim
@@ -8,13 +8,16 @@
 {.push raises: [], gcsafe.}
 
 import
-  std/[os, sequtils, times],
+  std/times,
   stew/[byteutils, base10],
   chronicles,
   ./spec/eth2_apis/rest_beacon_client,
   ./spec/signatures,
   ./validators/keystore_management,
-  "."/[conf, beacon_clock, filepath]
+  ./[conf, beacon_clock, filepath]
+
+from std/os import dirExists, `/`
+from std/sequtils import mapIt
 
 type
   ValidatorStorageKind {.pure.} = enum

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -16,6 +16,8 @@ import
 
 from std/algorithm import fill, isSorted, sort
 from std/sequtils import anyIt, mapIt
+from ./deposit_sig_cache import verify_deposit_signature_cached
+from ./helpers import is_builder_withdrawal_credential
 
 export extras, forks, validator, chronicles
 
@@ -48,11 +50,6 @@ func decrease_balance*(
 func is_compounding_withdrawal_credential*(
     withdrawal_credentials: Eth2Digest): bool =
   withdrawal_credentials.data[0] == COMPOUNDING_WITHDRAWAL_PREFIX
-
-# https://github.com/ethereum/consensus-specs/blob/v1.6.0-beta.0/specs/gloas/beacon-chain.md#new-is_builder_withdrawal_credential
-func is_builder_withdrawal_credential*(
-    withdrawal_credentials: Eth2Digest): bool =
-  withdrawal_credentials.data[0] == BUILDER_WITHDRAWAL_PREFIX
 
 # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.7/specs/electra/beacon-chain.md#new-has_compounding_withdrawal_credential
 func has_compounding_withdrawal_credential*(
@@ -2264,9 +2261,12 @@ func add_builder_to_registry*(
     state: var (gloas.BeaconState | heze.BeaconState),
     bucket_sorted_builders: var BucketSortedValidators,
     pubkey: ValidatorPubKey, version: uint8,
-    execution_address: ExecutionAddress, amount: Gwei, slot: Slot) =
+    execution_address: ExecutionAddress, amount: Gwei, slot: Slot,
+    reuseFreedSlots = true) =
   let
-    index = get_index_for_new_builder(state)
+    index =
+      if reuseFreedSlots: get_index_for_new_builder(state)
+      else: BuilderIndex(len(state.builders))
     builder = Builder(
       pubkey: pubkey,
       version: version,
@@ -2328,7 +2328,7 @@ func onboard_builders_from_pending_deposits*(
       try:
         let pending_deposit =
           pending_deposits[pending_deposits_idx[deposit.pubkey]]
-        if verify_deposit_signature(
+        if verify_deposit_signature_cached(
             cfg.GENESIS_FORK_VERSION,
             DepositData(
               pubkey: pending_deposit.pubkey,
@@ -2340,7 +2340,7 @@ func onboard_builders_from_pending_deposits*(
       except KeyError:
         discard
 
-      if not verify_deposit_signature(
+      if not verify_deposit_signature_cached(
           cfg.GENESIS_FORK_VERSION,
           DepositData(
             pubkey: deposit.pubkey,
@@ -2349,11 +2349,13 @@ func onboard_builders_from_pending_deposits*(
             signature: deposit.signature)):
         continue
 
+      # Onboarding is append-only: builders starts empty and none exit mid-loop,
+      # so there is never a freed slot to reuse. Skip the O(n) reuse scan.
       add_builder_to_registry(
         state, bucket_sorted_builders[], deposit.pubkey,
         PAYLOAD_BUILDER_VERSION,
         builder_execution_address(deposit.withdrawal_credentials),
-        deposit.amount, deposit.slot)
+        deposit.amount, deposit.slot, reuseFreedSlots = false)
     else:
       # Top up the balance of the existing builder
       state.builders.mitem(opt_builder_index.get).balance += deposit.amount

--- a/beacon_chain/spec/block_id.nim
+++ b/beacon_chain/spec/block_id.nim
@@ -1,15 +1,15 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import
   chronicles,
-  "."/[beacon_time, digest]
+  ./[beacon_time, digest]
 
 export beacon_time, digest
 

--- a/beacon_chain/spec/deposit_sig_cache.nim
+++ b/beacon_chain/spec/deposit_sig_cache.nim
@@ -1,0 +1,49 @@
+# beacon_chain
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+
+import
+  std/tables,
+  ./datatypes/[base, electra],
+  ./eth2_merkleization
+
+from ./helpers import is_builder_withdrawal_credential
+from ./signatures import verify_deposit_signature
+
+var depositSigValidity {.threadvar.}: Table[Eth2Digest, bool]
+
+func depositSigKey(deposit: DepositData): Eth2Digest =
+  hash_tree_root(deposit)
+
+func verify_deposit_signature_cached*(
+    genesis_fork_version: Version, deposit: DepositData): bool =
+  {.cast(noSideEffect).}:
+    let key = depositSigKey(deposit)
+    depositSigValidity.withValue(key, v):
+      return v[]
+    let ok = verify_deposit_signature(genesis_fork_version, deposit)
+    depositSigValidity[key] = ok
+    ok
+
+proc cacheBuilderDepositSigs*[N: static Limit](
+    genesis_fork_version: Version, deposits: List[DepositRequest, N]) =
+  for d in deposits:
+    if not is_builder_withdrawal_credential(d.withdrawal_credentials):
+      continue
+    let
+      dd = DepositData(
+        pubkey: d.pubkey,
+        withdrawal_credentials: d.withdrawal_credentials,
+        amount: d.amount,
+        signature: d.signature)
+      key = depositSigKey(dd)
+    if key notin depositSigValidity:
+      depositSigValidity[key] = verify_deposit_signature(genesis_fork_version, dd)
+
+proc clearBuilderDepositSigCache*() =
+  reset(depositSigValidity)

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -31,6 +31,11 @@ const
   ETH_TO_GWEI = 1_000_000_000.Gwei
   GWEI_TO_WEI* = 1_000_000_000'u64 # 1 Gwei = 10^9 Wei
 
+# https://github.com/ethereum/consensus-specs/blob/v1.6.0-beta.0/specs/gloas/beacon-chain.md#new-is_builder_withdrawal_credential
+func is_builder_withdrawal_credential*(
+    withdrawal_credentials: Eth2Digest): bool =
+  withdrawal_credentials.data[0] == BUILDER_WITHDRAWAL_PREFIX
+
 func toEther*(gwei: Gwei): Ether =
   (gwei div ETH_TO_GWEI).Ether
 

--- a/beacon_chain/spec/helpers_el.nim
+++ b/beacon_chain/spec/helpers_el.nim
@@ -10,7 +10,7 @@
 import
   std/typetraits,
   eth/common/eth_types_rlp,
-  "."/[helpers, state_transition_block]
+  ./[helpers, state_transition_block]
 
 func readExecutionTransaction(
     txBytes: bellatrix.Transaction): Result[EthTransaction, string] =

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -20,8 +20,8 @@ import
   taskpools,
   bearssl/rand,
   # Internal
-  "."/[helpers, beaconstate, forks, signatures],
-  "."/datatypes/[altair, bellatrix, phase0]
+  ./[helpers, beaconstate, forks, signatures],
+  ./datatypes/[altair, bellatrix, phase0]
 
 export results, rand, altair, phase0, taskpools, signatures
 

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -46,8 +46,8 @@ import
   stew/objects,
   ../extras,
   ./[
-    beaconstate, eth2_merkleization, forks, helpers, signatures, state_transition_block,
-    state_transition_epoch, validator,
+    beaconstate, eth2_merkleization, forks, helpers, signatures,
+    state_transition_block, state_transition_epoch, validator,
   ]
 
 export results, extras, state_transition_block

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -27,7 +27,8 @@
 import
   chronicles,
   ../extras,
-  ./[beaconstate, eth2_merkleization, forks, helpers, validator, signatures],
+  ./[beaconstate, deposit_sig_cache, eth2_merkleization, forks, helpers, validator,
+     signatures],
   kzg4844/kzg_abi, kzg4844/kzg
 
 from std/algorithm import fill, sorted
@@ -321,7 +322,7 @@ proc process_attester_slashing*(
 
   ok((proposer_reward, cur_exit_queue_info))
 
-from ".."/validator_bucket_sort import
+from ../validator_bucket_sort import
   BucketSortedValidators, add, findValidatorIndex, sortValidatorBuckets
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.0/specs/phase0/beacon-chain.md#deposits
@@ -1806,6 +1807,13 @@ proc process_block*(
   operations_rewards.sync_aggregate = ? process_sync_aggregate(
     state, blck.body.sync_aggregate, total_active_balance, flags, cache)
 
+  # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.13/specs/gloas/fork.md#new-onboard_builders_from_pending_deposits
+  # "In the slots leading up to the fork, implementations SHOULD validate
+  # pending deposit signatures and cache the results. The pending deposit queue
+  # might be large and verifying many signatures at the fork could be slow."
+  cacheBuilderDepositSigs(
+    cfg.GENESIS_FORK_VERSION, blck.body.execution_requests.deposits)
+
   ok(operations_rewards)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.12/specs/gloas/fork-choice.md#new-verify_execution_payload_envelope
@@ -1902,6 +1910,9 @@ proc process_block*(
     parent_slot)
   operations_rewards.sync_aggregate = ? process_sync_aggregate(
     state, blck.body.sync_aggregate, total_active_balance, flags, cache)
+
+  if state.finalized_checkpoint.epoch >= cfg.GLOAS_FORK_EPOCH:
+    clearBuilderDepositSigCache()
 
   ok(operations_rewards)
 

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -1184,8 +1184,8 @@ func process_historical_summaries_update*(
 
   ok()
 
-from "."/signatures import verify_deposit_signature
-from ".."/validator_bucket_sort import
+from ./signatures import verify_deposit_signature
+from ../validator_bucket_sort import
   BucketSortedValidators, add, findValidatorIndex, sortValidatorBuckets
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.7/specs/electra/beacon-chain.md#new-apply_pending_deposit

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -10,7 +10,7 @@
 
 import
   std/algorithm,
-  "."/[crypto, helpers]
+  ./[crypto, helpers]
 from std/sequtils import mapIt
 from std/math import `^`
 export helpers

--- a/tests/test_validator_change_pool.nim
+++ b/tests/test_validator_change_pool.nim
@@ -12,7 +12,7 @@ import
   ../beacon_chain/spec/[forks, presets, signatures, state_transition],
   ../beacon_chain/consensus_object_pools/[
     block_quarantine, blockchain_dag, validator_change_pool],
-  "."/[testutil, testblockutil, testdbutil]
+  ./[testutil, testblockutil, testdbutil]
 
 func makeSignedBeaconBlockHeader(
     fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot,


### PR DESCRIPTION
Defangs the 3 "Pre" scenarios from https://github.com/jtraglia/kurtosis-devnets/tree/e746b2c3d36e44faabda7e0645b81717ab426820/gloas-deposits (s2, s3, and s5)

The "Post" ones were obviated by other protocol changes.