### PR TITLE
Fix head payload status update

### DIFF
--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -194,18 +194,9 @@ type
       ## The most recently known head, as chosen by fork choice; might be
       ## optimistic
 
-    headPayload*: BlockRef
-      ## The known payload head that is chosen by fork choice. It will be used
-      ## on the next block proposal for building payload on either the current
-      ## head (parent) or the parent of the current head (grandparent).
-      ##
-      ## Used only since Gloas. Always read values from the head instead of
-      ## headPayload. It is for deriving the should_extend_payload status.
-      ##
-      ## In the usual scenarios it should point to either`dag.head` or
-      ## `dag.head.parent`. It would be nil at the beginning of Gloas fork,
-      ## either Gloas genesis or upgrading from pre-Gloas. It would also be nil
-      ## if it is in a different fork from the head at node startup.
+    headPayloadFull*: bool
+      ## The head payload status from the fork choice. It is a raw flag that
+      ## cannot be used directly.
 
     backfill*: BeaconBlockSummary
       ## The backfill points to the oldest block with an unbroken ancestry from

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -592,6 +592,7 @@ func init*(
     slot: Slot,
     blockRoot: Eth2Digest,
     stateRoot: Eth2Digest,
+    payloadFull: bool,
     epochTransition: bool,
     currentEpochDepRoot: Eth2Digest,
     nextEpochDepRoot: Eth2Digest
@@ -602,6 +603,7 @@ func init*(
       slot: slot,
       block_root: blockRoot,
       state_root: stateRoot,
+      payload_status: if payloadFull: "full" else: "empty",
       epoch_transition: epochTransition,
       current_epoch_dependent_root: currentEpochDepRoot,
       next_epoch_dependent_root: nextEpochDepRoot

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -2654,11 +2654,6 @@ proc hasExecutionCheckpoint*(
   # Return true if it is either EMPTY or FULL
   parentBlockHash == latestBlockHash or parentBlockHash == latestParentHash
 
-func isPayloadStatusFull*(dag: ChainDAGRef, head: BlockRef): bool =
-  ## Whether `head.payload_status == PAYLOAD_STATUS_FULL`, as consumed by
-  ## https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.12/specs/gloas/fork-choice.md#new-should_build_on_full
-  head == dag.headPayload
-
 # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.13/specs/gloas/validator.md#attestation
 func attestationDataIndex*(
     dag: ChainDAGRef, blck: BlockRef, slot: Slot): CommitteeIndex =
@@ -2668,7 +2663,7 @@ func attestationDataIndex*(
   let payloadPresent =
     if blck == dag.head:
       # If nothing extends the head yet, fork choice holds the verdict
-      dag.isPayloadStatusFull(blck)
+      dag.headPayloadFull
     else:
       # Else a descendant already recorded whether it extended this payload
       withState(dag.headState):
@@ -2967,39 +2962,13 @@ proc updateHead*(
       dag.onFinHappened(dag, data)
 
 proc updateHeadExecutionPayload*(
-    dag: ChainDAGRef, full: bool, headChanged: bool) =
+    dag: ChainDAGRef, full: bool) =
   ## Update the execution payload of the head block since Gloas, which should
   ## usually be invoked after the call of updateHead().
   if dag.head.slot.epoch < dag.cfg.GLOAS_FORK_EPOCH:
     return
-  let newHeadPayload =
-    if full:
-      dag.head
-    else:
-      dag.head.parent
-  if newHeadPayload == dag.headPayload:
-    return
-  dag.headPayload = newHeadPayload
 
-  # `updateHead` already emits head_v2 on a head change; only emit here for a
-  # pure payload flip (head unchanged) to avoid double-emitting.
-  if not headChanged and not isNil(dag.onHeadV2Changed):
-    # https://github.com/ethereum/beacon-APIs/blob/v5.0.0-alpha.2/apis/eventstream/index.yaml#L62-L66
-    let
-      finalized_checkpoint = dag.headState.finalized_checkpoint
-      finalizedSlot =
-        max(finalized_checkpoint.epoch.start_slot(), dag.finalizedHead.slot)
-      finalizedHead = dag.head.atSlot(finalizedSlot)
-      epochTransition = (finalizedHead != dag.finalizedHead)
-
-      headEpoch = dag.head.slot.epoch()
-      curEpochDepRoot = dag.getEpochDepRoot(headEpoch, 1)
-      nextEpochDepRoot = dag.getEpochDepRoot(headEpoch, 0)
-
-    dag.onHeadV2Changed(HeadV2ChangeInfoObject.init(
-      dag.headState.kind, dag.head.slot, dag.head.root,
-      dag.headState.root, epochTransition, curEpochDepRoot,
-      nextEpochDepRoot))
+  dag.headPayloadFull = full
 
 proc isInitialized*(T: type ChainDAGRef, db: BeaconChainDB): Result[void, cstring] =
   ## Lightweight check to see if it is likely that the given database has been

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -2878,18 +2878,6 @@ proc updateHead*(
                                        depRoot)
     dag.onHeadChanged(data)
 
-  if not isNil(dag.onHeadV2Changed):
-    # https://github.com/ethereum/beacon-APIs/blob/v5.0.0-alpha.2/apis/eventstream/index.yaml#L62-L66
-    let
-      headEpoch = dag.head.slot.epoch()
-      curEpochDepRoot = dag.getEpochDepRoot(headEpoch, 1)
-      nextEpochDepRoot = dag.getEpochDepRoot(headEpoch, 0)
-
-    dag.onHeadV2Changed(HeadV2ChangeInfoObject.init(
-      dag.headState.kind, dag.head.slot, dag.head.root,
-      dag.headState.root, epochTransition, curEpochDepRoot,
-      nextEpochDepRoot))
-
   let (isAncestor, ancestorDepth) = lastHead.getDepth(newHead)
   if not(isAncestor):
     notice "Updated head block with chain reorg",
@@ -2962,13 +2950,35 @@ proc updateHead*(
       dag.onFinHappened(dag, data)
 
 proc updateHeadExecutionPayload*(
-    dag: ChainDAGRef, full: bool) =
+    dag: ChainDAGRef, full: bool, headChanged: bool) =
   ## Update the execution payload of the head block since Gloas, which should
   ## usually be invoked after the call of updateHead().
   if dag.head.slot.epoch < dag.cfg.GLOAS_FORK_EPOCH:
     return
 
+  let statusChanged = dag.headPayloadFull != full
+  if not (headChanged or statusChanged):
+    return
+
   dag.headPayloadFull = full
+
+  if not isNil(dag.onHeadV2Changed):
+    # https://github.com/ethereum/beacon-APIs/blob/v5.0.0-alpha.2/apis/eventstream/index.yaml#L62-L66
+    let
+      finalized_checkpoint = dag.headState.finalized_checkpoint
+      finalizedSlot =
+        max(finalized_checkpoint.epoch.start_slot(), dag.finalizedHead.slot)
+      finalizedHead = dag.head.atSlot(finalizedSlot)
+      epochTransition = (finalizedHead != dag.finalizedHead)
+
+      headEpoch = dag.head.slot.epoch()
+      curEpochDepRoot = dag.getEpochDepRoot(headEpoch, 1)
+      nextEpochDepRoot = dag.getEpochDepRoot(headEpoch, 0)
+
+    dag.onHeadV2Changed(HeadV2ChangeInfoObject.init(
+      dag.headState.kind, dag.head.slot, dag.head.root,
+      dag.headState.root, full, epochTransition, curEpochDepRoot,
+      nextEpochDepRoot))
 
 proc isInitialized*(T: type ChainDAGRef, db: BeaconChainDB): Result[void, cstring] =
   ## Lightweight check to see if it is likely that the given database has been

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -259,7 +259,6 @@ proc updateHead*(self: var ConsensusManager, wallSlot: Slot) =
         head = shortLog(self.dag.head), wallSlot
       return
 
-  let headChanged = newHead.blck != self.dag.head
   self.updateHead(newHead.blck)
   self.dag.updateHeadExecutionPayload(newHead.full)
 

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -261,7 +261,7 @@ proc updateHead*(self: var ConsensusManager, wallSlot: Slot) =
 
   let headChanged = newHead.blck != self.dag.head
   self.updateHead(newHead.blck)
-  self.dag.updateHeadExecutionPayload(newHead.full, headChanged)
+  self.dag.updateHeadExecutionPayload(newHead.full)
 
 func isSynced(dag: ChainDAGRef, wallSlot: Slot): bool =
   # This is a tweaked version of the beacon_validators isSynced. TODO, refactor
@@ -391,7 +391,7 @@ proc prepareNextSlot*(
       when consensusFork >= ConsensusFork.Gloas:
         let shouldExtend = self.attestationPool[].forkChoice
           .should_build_on_full(
-            dag, head, dag.isPayloadStatusFull(head), proposalSlot)
+            dag, head, dag.headPayloadFull, proposalSlot)
       let
         timestamp = dag.timeParams
           .compute_timestamp_at_slot(forkyState.data, proposalSlot)

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -258,9 +258,10 @@ proc updateHead*(self: var ConsensusManager, wallSlot: Slot) =
       warn "Head selection failed, using previous head",
         head = shortLog(self.dag.head), wallSlot
       return
+    headChanged = newHead.blck != self.dag.head
 
   self.updateHead(newHead.blck)
-  self.dag.updateHeadExecutionPayload(newHead.full)
+  self.dag.updateHeadExecutionPayload(newHead.full, headChanged)
 
 func isSynced(dag: ChainDAGRef, wallSlot: Slot): bool =
   # This is a tweaked version of the beacon_validators isSynced. TODO, refactor

--- a/beacon_chain/fork_choice/fork_choice_epbs.nim
+++ b/beacon_chain/fork_choice/fork_choice_epbs.nim
@@ -115,7 +115,7 @@ proc is_bid_compatible_with_head*(
   if bid.parent_block_root != head.root:
     return false
   if self.should_build_on_full(
-      dag, head, dag.isPayloadStatusFull(head), bid.slot):
+      dag, head, dag.headPayloadFull, bid.slot):
     return headBlockHash.isSome and
       bid.parent_block_hash == headBlockHash.unsafeGet
   builds_on_parent_payload

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -509,11 +509,6 @@ proc initFullNode(
       var res = data
       res.data.optimistic = Opt.some dag.is_optimistic(
         BlockId(slot: data.data.slot, root: data.data.block_root))
-      res.data.payload_status =
-        if dag.db.containsExecutionPayloadEnvelope(data.data.block_root):
-          "full"
-        else:
-          "empty"
       res
     node.eventBus.headV2Queue.emit(eventData)
   proc onChainReorg(data: ReorgInfoObject) =

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -1587,7 +1587,7 @@ proc handleValidatorDuties*(node: BeaconNode, lastSlot, slot: Slot) {.async: (ra
   let newHead = await handleProposal(
     node, head,
     node.attestationPool[].forkChoice.should_build_on_full(
-      node.dag, head, node.dag.isPayloadStatusFull(head), slot), slot)
+      node.dag, head, node.dag.headPayloadFull, slot), slot)
   head = newHead
 
   # The latest point in time when we'll be sending out attestations


### PR DESCRIPTION
- `updateHeadExecutionPayload` is always called after `updateHead`, `head_v2` event is always a duplicate in the call site.
- `updateHeadExecutionPayload` takes `bool` and converts to `BlockRef`, and converts to `bool` in `isPayloadStatusFull`. As `updateHeadExecutionPayload` is always called after `updateHead`, `headPayload` is reset on head or payload changed and so the conversion is wasteful.
