### PR TITLE
feat: parent check on envelopes

### DIFF
--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -534,6 +534,18 @@ proc addHeadExecutionPayload*(
       return err(PayloadVerifierError.UnviableFork)
     return err(PayloadVerifierError.MissingParent)
 
+  # Check execution parent's envelope
+  let epRes = dag.executionParent(
+    blck.parent, signedEnvelope.message.payload.parent_hash)
+  if epRes.isSome():
+    if epRes.get().slot.epoch() >= dag.cfg.GLOAS_FORK_EPOCH and
+        epRes.get().slot > GENESIS_SLOT and
+        not dag.db.containsExecutionPayloadEnvelope(epRes.get().root):
+      return err(PayloadVerifierError.MissingParent)
+  elif not dag.hasExecutionCheckpoint(
+      blck.parent, signedEnvelope.message.payload.parent_hash):
+    return err(PayloadVerifierError.MissingParent)
+
   # Load state cache for updateState() and state transition.
   var cache: StateCache
   loadStateCache(dag, cache, blck.bid, blck.slot().epoch())


### PR DESCRIPTION
This PR and `syncv3` are interdependent regards on envelope byRange handling, but would be best to merge after `syncv3`.

Keep as draft as it is not safe to merge for the devnets.