### PR TITLE
revert #8853

### DIFF
--- a/beacon_chain/gossip_processing/batch_validation.nim
+++ b/beacon_chain/gossip_processing/batch_validation.nim
@@ -12,8 +12,8 @@ import
   stew/ptrops,
   metrics,
   # Status
-  chronicles, chronos,
-  ../spec/signatures_batch,
+  chronicles, chronos, chronos/threadsync,
+  ../spec/[peerdas_helpers, signatures_batch],
   ../consensus_object_pools/[blockchain_dag, spec_cache]
 
 export signatures_batch, blockchain_dag
@@ -88,8 +88,7 @@ type
     Valid
     Timeout
 
-  FutureBatchResult = Future[BatchResult].Raising([])
-  FutureTask = Future[void].Raising([])
+  FutureBatchResult = Future[BatchResult].Raising([CancelledError])
 
   Eager = proc(): bool {.gcsafe, raises: [].}
     ## Callback that returns true if eager processing should be done to lower
@@ -108,7 +107,8 @@ type
 
   VerifierItem = object
     verifier: ref BatchVerifier
-    inflight: Future[void].Raising([])
+    signal: ThreadSignalPtr
+    inflight: Future[void].Raising([CancelledError])
 
   BatchCrypto* = object
     batches: Deque[ref Batch]
@@ -125,7 +125,9 @@ type
       ## Each batch verification reqires a separate verifier
     verifier: int
 
-    kzgLimit: AsyncSemaphore
+    kzgSignals: AsyncQueue[ThreadSignalPtr]
+      ## Pending KZG verifications, InflightKzgVerifications verifiers
+
     pruneTime: Moment ## last time we had to prune something
 
     counts: tuple[signatures, batches, aggregates: int64]
@@ -138,9 +140,6 @@ type
 
     processor: Future[void].Raising([CancelledError])
 
-    disp: DispatcherHandle
-      # Cached thread-local dispatcher handle
-
   BatchTask = object
     ok: Atomic[bool]
     setsPtr: ptr UncheckedArray[SignatureSet]
@@ -148,8 +147,7 @@ type
     secureRandomBytes: array[32, byte]
     taskpool: Taskpool
     cache: ptr BatchedBLSVerifierCache
-    future: FutureTask
-    disp: DispatcherHandle
+    signal: ThreadSignalPtr
 
   KzgTask = object
     ok: Atomic[bool]
@@ -158,30 +156,44 @@ type
     cellsPtr: ptr UncheckedArray[KzgCell]
     proofsPtr: ptr UncheckedArray[KzgProof]
     numCells: int
-    future: FutureTask
-    disp: DispatcherHandle
+    signal: ThreadSignalPtr
 
 proc new*(
-    T: type BatchCrypto,
-    rng: ref HmacDrbgContext,
-    timeParams: TimeParams,
-    eager: Eager,
-    genesis_validators_root: Eth2Digest,
-    taskpool: Taskpool,
-): ref BatchCrypto =
+    T: type BatchCrypto, rng: ref HmacDrbgContext, timeParams: TimeParams,
+    eager: Eager, genesis_validators_root: Eth2Digest, taskpool: Taskpool):
+    Result[ref BatchCrypto, string] =
   let res = (ref BatchCrypto)(
-    taskpool: taskpool,
-    rng: rng,
-    timeParams: timeParams,
+    taskpool: taskpool, rng: rng, timeParams: timeParams,
     eager: eager,
     genesis_validators_root: genesis_validators_root,
-    pruneTime: Moment.now(),
-    kzgLimit: newAsyncSemaphore(InflightKzgVerifications),
-    disp: getThreadDispatcher().handle(),
-  )
-  for i in 0 ..< res.verifiers.len:
-    res.verifiers[i] = VerifierItem(verifier: BatchVerifier.new(rng, taskpool))
-  res
+    pruneTime: Moment.now())
+
+  for i in 0..<res.verifiers.len:
+    res.verifiers[i] = VerifierItem(
+      verifier: BatchVerifier.new(rng, taskpool),
+      signal: block:
+        let sig = ThreadSignalPtr.new()
+        sig.valueOr:
+          for j in 0..<i:
+            discard res.verifiers[j].signal.close()
+          return err(sig.error())
+    )
+
+  res.kzgSignals = newAsyncQueue[ThreadSignalPtr](
+    maxsize = InflightKzgVerifications)
+  for _ in 0..<InflightKzgVerifications:
+    let sig = ThreadSignalPtr.new().valueOr:
+      for j in 0..<res.verifiers.len:
+        discard res.verifiers[j].signal.close()
+      for j in 0..<res.kzgSignals.len:
+        discard res.kzgSignals[j].close()
+      return err(error)
+    try:
+      res.kzgSignals.addLastNoWait(sig)
+    except AsyncQueueFullError:
+      raiseAssert "Unreachable, maxsize items are added"
+
+  ok res
 
 func full(batch: Batch): bool =
   batch.items.len() >= BatchedCryptoSize
@@ -195,7 +207,6 @@ proc complete(batchItem: var BatchItem, v: BatchResult) =
 
 proc complete(batchItem: var BatchItem, ok: bool) =
   batchItem.fut.complete(if ok: BatchResult.Valid else: BatchResult.Invalid)
-  batchItem.fut = nil
 
 proc skip(batch: var Batch) =
   for res in batch.items.mitems():
@@ -227,14 +238,6 @@ proc complete(batchCrypto: var BatchCrypto, batch: var Batch, ok: bool) =
 
     reset(batchCrypto.counts)
 
-proc completeTask[Task](udata: pointer) {.nimcall, gcsafe, raises: [].} =
-  ## Completion callback for batchVerifyTask - completes the future on
-  ## the async thread via callSoon
-  let task = cast[ptr Task](udata)
-  let fut = move(task[].future)
-  if not fut.finished():
-    fut.complete()
-
 proc batchVerifyTask(task: ptr BatchTask) {.nimcall.} =
   # Task suitable for running in taskpools - look, no GC!
   let
@@ -245,8 +248,7 @@ proc batchVerifyTask(task: ptr BatchTask) {.nimcall.} =
 
   task[].ok.store(sync ok)
 
-  # Signal completion on the async thread via callSoon
-  callSoon(task[].disp, completeTask[BatchTask], task)
+  discard task[].signal.fireSync()
 
 proc spawnBatchVerifyTask(tp: Taskpool, task: ptr BatchTask) =
   # Inlining this `proc` leads to compilation problems on Nim 2.0
@@ -265,8 +267,7 @@ proc kzgProofsTask(task: ptr KzgTask) {.nimcall.} =
 
   task[].ok.store(ok)
 
-  # Signal completion on the async thread via callSoon
-  callSoon(task[].disp, completeTask[KzgTask], task)
+  discard task[].signal.fireSync()
 
 proc spawnKzgTask(tp: Taskpool, task: ptr KzgTask) =
   # Keep `tp.spawn` out of `{.async.}` procs - see `spawnBatchVerifyTask`
@@ -288,28 +289,30 @@ func combineAll(
   sigsets
 
 proc batchVerifyAsync(
-    verifier: ref BatchVerifier, batch: ref Batch, disp: DispatcherHandle
-): Future[bool] {.async: (raises: []).} =
+    verifier: ref BatchVerifier,
+    signal: ThreadSignalPtr,
+    batch: ref Batch): Future[bool] {.async: (raises: [CancelledError]).} =
   let sigsets = batch[].multiSets.combineAll(verifier)
-  let future = FutureTask.init("batch_verify", {FutureFlag.OwnCancelSchedule})
   var task = BatchTask(
     setsPtr: makeUncheckedArray(baseAddr sigsets),
     numSets: sigsets.len,
     taskpool: verifier[].taskpool,
     cache: addr verifier[].sigVerifCache,
-    future: future,
-    disp: disp,
+    signal: signal,
   )
   verifier[].rng[].generate(task.secureRandomBytes)
 
-  # The loop below never cancels tasks, thus the `task` instace stays alive
-  # until after the task is finished
+  # task will stay allocated in the async environment at least until the signal
+  # has fired at which point it's safe to release it
   let taskPtr = addr task
   doAssert verifier[].taskpool.numThreads > 1,
-    "Must have at least one separate thread for task pool"
+    "Must have at least one separate thread or signal will never be fired"
   verifier[].taskpool.spawnBatchVerifyTask(taskPtr)
-
-  await future
+  try:
+    await signal.wait()
+  except AsyncError as exc:
+    warn "Batch verification verification failed - report bug", err = exc.msg
+    return false
 
   # `sigsets` must be used after the `await` or it is freed on suspension
   # while the worker still reads it through `task.setsPtr`:
@@ -319,8 +322,10 @@ proc batchVerifyAsync(
   task.ok.load()
 
 proc processBatch(
-    batchCrypto: ref BatchCrypto, batch: ref Batch, verifier: ref BatchVerifier
-) {.async: (raises: []).} =
+    batchCrypto: ref BatchCrypto,
+    batch: ref Batch,
+    verifier: ref BatchVerifier,
+    signal: ThreadSignalPtr) {.async: (raises: [CancelledError]).} =
   let numSets = batch[].multiSets.len
 
   if numSets == 0:
@@ -361,7 +366,7 @@ proc processBatch(
         break
       r
     elif batchCrypto[].taskpool.numThreads > 1 and numSets > 3:
-      await batchVerifyAsync(verifier, batch, batchCrypto.disp)
+      await batchVerifyAsync(verifier, signal, batch)
     else:
       let secureRandomBytes = verifier[].rng[].generate(array[32, byte])
       batchVerifySerial(
@@ -403,8 +408,9 @@ proc processLoop(batchCrypto: ref BatchCrypto) {.async: (raises: [CancelledError
       await batchCrypto[].verifiers[verifier].inflight
 
     batchCrypto[].verifiers[verifier].inflight = batchCrypto.processBatch(
-      batchCrypto[].batches.popFirst(), batchCrypto[].verifiers[verifier].verifier
-    )
+      batchCrypto[].batches.popFirst(),
+      batchCrypto[].verifiers[verifier].verifier,
+      batchCrypto[].verifiers[verifier].signal)
 
 proc getBatch(batchCrypto: var BatchCrypto): ref Batch =
   if batchCrypto.batches.len() == 0 or
@@ -420,11 +426,11 @@ proc scheduleProcessor(batchCrypto: ref BatchCrypto) =
     batchCrypto.processor = batchCrypto.processLoop()
 
 proc verifySoon(
-    batchCrypto: ref BatchCrypto, name: static string, sigset: SignatureSet
-): Future[BatchResult] {.async: (raises: [], raw: true).} =
+    batchCrypto: ref BatchCrypto, name: static string,
+    sigset: SignatureSet): Future[BatchResult]{.async: (raises: [CancelledError], raw: true).} =
   let
     batch = batchCrypto[].getBatch()
-    fut = newFuture[BatchResult](name, {FutureFlag.OwnCancelSchedule})
+    fut = newFuture[BatchResult](name)
 
   batch[].multiSets.withValue(sigset.message, multiSet):
     multiSet[].add sigset
@@ -679,7 +685,7 @@ proc scheduleKzgCheck(
     batchCrypto: ref BatchCrypto,
     commitments: seq[KzgCommitment], cellIndices: seq[CellIndex],
     cells: seq[KzgCell], proofs: seq[KzgProof]):
-    Future[BatchResult] {.async: (raises: []).} =
+    Future[BatchResult] {.async: (raises: [CancelledError]).} =
   ## Verify the KZG proofs of a data column on the task pool
   if batchCrypto.taskpool.numThreads <= 1:
     return toBatchResult verifyCellKzgProofBatch(
@@ -687,13 +693,12 @@ proc scheduleKzgCheck(
 
   let
     created = Moment.now()
-
-  await noCancel batchCrypto.kzgLimit.acquire()
+    signal = await batchCrypto.kzgSignals.popFirst()
   defer:
     try:
-      batchCrypto.kzgLimit.release()
-    except AsyncError:
-      raiseAssert "Unreachable"
+      batchCrypto[].kzgSignals.addLastNoWait(signal)
+    except AsyncQueueFullError:
+      raiseAssert "Unreachable, pops and adds are balanced"
 
   let
     startTick = Moment.now()
@@ -710,26 +715,23 @@ proc scheduleKzgCheck(
 
     return BatchResult.Timeout
 
-  let future = FutureTask.init("kzg_verify", {FutureFlag.OwnCancelSchedule})
   var task = KzgTask(
     commitmentsPtr: makeUncheckedArray(baseAddr commitments),
     cellIndicesPtr: makeUncheckedArray(baseAddr cellIndices),
     cellsPtr: makeUncheckedArray(baseAddr cells),
     proofsPtr: makeUncheckedArray(baseAddr proofs),
     numCells: cells.len,
-    future: future,
-    disp: batchCrypto.disp,
-  )
+    signal: signal)
 
-  # task will stay allocated in the async environment at least until the
-  # callSoon completion callback has fired
+  # task will stay allocated in the async environment at least until the signal
+  # has fired at which point it's safe to release it
   let taskPtr = addr task
   batchCrypto[].taskpool.spawnKzgTask(taskPtr)
-
-  await future
-
-  # TODO https://github.com/nim-lang/Nim/issues/26041
-  #      don't forget to touch task after await
+  try:
+    await signal.wait()
+  except AsyncError as exc:
+    warn "Column KZG proof verification failed - report bug", err = exc.msg
+    return BatchResult.Invalid
 
   toBatchResult(task.ok.load())
 

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -239,15 +239,12 @@ proc new*(T: type Eth2Processor,
     envelopeQuarantine: envelopeQuarantine,
     getCurrentBeaconTime: getBeaconTime,
     batchCrypto: BatchCrypto.new(
-      rng,
-      dag.cfg.timeParams,
-      eager = proc(): bool =
-        # Only run eager attestation signature verification if we're not
-        # processing blocks in order to give priority to block processing
-        not blockProcessor[].hasBlocks(),
-      genesis_validators_root = dag.genesis_validators_root,
-      taskpool,
-    ),
+      rng, dag.cfg.timeParams,
+      # Only run eager attestation signature verification if we're not
+      # processing blocks in order to give priority to block processing
+      eager = proc(): bool = not blockProcessor[].hasBlocks(),
+      genesis_validators_root = dag.genesis_validators_root, taskpool).expect(
+        "working batcher")
   )
 
 # Each validator logs, validates then passes valid data to its destination

--- a/beacon_chain/spec/peerdas_helpers.nim
+++ b/beacon_chain/spec/peerdas_helpers.nim
@@ -9,20 +9,24 @@
 
 # Uncategorized helper functions from the spec
 import
-  chronicles,
-  chronos,
-  results,
-  taskpools,
+  chronos, chronos/threadsync, chronicles, results, taskpools,
   eth/p2p/discoveryv5/node,
   kzg4844/kzg,
   ssz_serialization/[proofs, types],
-  stew/[assign2, ptrops],
+  stew/assign2,
   ./[column_map, crypto, digest, helpers],
   ./datatypes/[deneb, fulu]
 
 from std/algorithm import sort
 from std/sequtils import anyIt, mapIt, newSeqWith, repeat, toSeq
 from stew/staticfor import staticFor
+
+# Generics sandwich (https://github.com/nim-lang/Nim/issues/11225): because
+# `recover_cells_and_proofs_parallel` is generic, its body is semchecked at
+# each callsite, where every symbol it references must also be visible -
+# including the `threadsync` ones. Re-export them so callers don't have to
+# import `threadsync` themselves just to instantiate it.
+export threadsync
 
 type
   CellBytes = array[fulu.CELLS_PER_EXT_BLOB, Cell]
@@ -128,39 +132,35 @@ proc recover_cells_and_proofs_parallel*(
     if blobCount != column.column.len:
       return err("DataColumns do not have the same length")
 
-  type
-    TaskFuture = Future[void].Raising([CancelledError])
-    Task = object
-      pendingIndices: seq[CellIndex]
-      pendingCells: seq[Cell]
-      ok: Flowvar[bool]
+  let tsp = ThreadSignalPtr.new().valueOr:
+    return err("Could not allocate signal")
 
-  let disp = getThreadDispatcher().handle()
-  var wait = TaskFuture.init("peerdas.task")
+  var wait = tsp.wait() # `wait` before task-ended check to avoid race
 
   defer:
     await wait.cancelAndWait()
+    # If there's an error closing the TSP, there's nothing we can do about it
+    # here..
+    discard tsp.close()
 
-  proc completeWait(udata: pointer) =
-    let wait = cast[ptr TaskFuture](udata)
-    if not wait[].finished():
-      wait[].complete()
+  type Task = object
+    pendingIndices: seq[CellIndex]
+    pendingCells: seq[Cell]
+    ok: Flowvar[bool]
 
-  proc workerRecover(
-      idxPtr: ptr CellIndex,
-      cellsPtr: ptr Cell,
-      columnCount: int,
-      res: ptr CellsAndProofs,
-      disp: DispatcherHandle,
-      wait: ptr TaskFuture,
-  ): bool =
+  proc workerRecover(idxPtr: ptr CellIndex, cellsPtr: ptr Cell,
+                     columnCount: int, res: ptr CellsAndProofs, tsp: ThreadSignalPtr): bool =
+    let
+      idxArr = cast[ptr UncheckedArray[CellIndex]](idxPtr)
+      cellsArr = cast[ptr UncheckedArray[Cell]](cellsPtr)
+    # Use toOpenArray to create views without copying
     defer:
-      disp.callSoon(completeWait, wait)
+      discard tsp.fireSync()
 
     res[] = recoverCellsAndKzgProofs(
-      idxPtr.makeOpenArray(columnCount), cellsPtr.makeOpenArray(columnCount)
-    ).valueOr:
-      return false
+      idxArr.toOpenArray(0, columnCount - 1),
+      cellsArr.toOpenArray(0, columnCount - 1)).valueOr:
+        return false
     true
 
   var
@@ -215,10 +215,13 @@ proc recover_cells_and_proofs_parallel*(
 
           try:
             await wait
+          except AsyncError:
+            hadError = true
+            break spawning
           except CancelledError:
             hadTimeout = true
             break spawning
-          wait = TaskFuture.init("peerdas.nexttask")
+          wait = tsp.wait()
         addr tasks[found]
 
       # Set up pointers to actual data
@@ -232,8 +235,7 @@ proc recover_cells_and_proofs_parallel*(
         addr taskPtr[].pendingCells[0],
         columnCount,
         addr res[spawned],
-        disp,
-        addr wait,
+        tsp,
       )
       inc spawned
 

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -95,7 +95,8 @@ cli do(
   let
     batchCrypto = BatchCrypto.new(
       rng, cfg.timeParams, eager,
-      genesis_validators_root = dag.genesis_validators_root, taskpool)
+      genesis_validators_root = dag.genesis_validators_root, taskpool).expect(
+        "working batcher")
     syncCommitteePool = newClone SyncCommitteeMsgPool.init(rng, cfg)
   var
     payloadAttestationPool = PayloadAttestationPool.init(dag)

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -66,7 +66,8 @@ suite "Gossip validation " & preset():
       info = ForkedEpochInfo()
     let batchCrypto {.used.} = BatchCrypto.new(
       rng, cfg.timeParams, eager = proc(): bool = false,
-      genesis_validators_root = dag.genesis_validators_root, taskpool)
+      genesis_validators_root = dag.genesis_validators_root, taskpool).expect(
+        "working batcher")
     # Slot 0 is a finalized slot - won't be making attestations for it..
     check cfg.process_slots(
       state[], state[].slot + 1, cache, info, {}).isOk()
@@ -320,7 +321,8 @@ suite "Gossip validation - Altair":
         cfg, cfg.makeTestDB(numValidators), validatorMonitor, {})
       batchCrypto = BatchCrypto.new(
         rng, cfg.timeParams, eager = proc(): bool = false,
-        genesis_validators_root = dag.genesis_validators_root, taskpool)
+        genesis_validators_root = dag.genesis_validators_root, taskpool).expect(
+          "working batcher")
     var
       cache: StateCache
       info: ForkedEpochInfo


### PR DESCRIPTION
As-pure-as-reasonable (no `nim-chronos` revert and keep existing `import` formatting) revert of:
- https://github.com/status-im/nimbus-eth2/pull/8853

The `geth-05` `unstable` Hoodi testnet node has been crashing with:
```
$ grep -B7 SIGSEGV *.log
service.20260820_0400.log-???(0): nimbus_beacon_node::handleStartUpCmd(var<conf::BeaconNodeConf>)
service.20260820_0400.log-???(0): nimbus_beacon_node::doRunBeaconNode(var<conf::BeaconNodeConf>, ref<bearssl_rand::HmacDrbgContext>)
service.20260820_0400.log-???(0): nimbus_beacon_node::run(ref<beacon_node::BeaconNodecolonObjectType_>, InternalRaisesFuture<void, tuple<futures::CancelledError> >) [clone .constprop.0]
service.20260820_0400.log-???(0): asyncengine::poll
service.20260820_0400.log-???(0): recover_cells_and_proofs_parallel::completeWait(pointer)
service.20260820_0400.log-???(0): 000000007f1ddd5084af
service.20260820_0400.log-???(0): signalHandler
service.20260820_0400.log:SIGSEGV: Illegal storage access. (Attempt to read from nil?)
--
service.20260820_0700.log-???(0): nimbus_beacon_node::handleStartUpCmd(var<conf::BeaconNodeConf>)
service.20260820_0700.log-???(0): nimbus_beacon_node::doRunBeaconNode(var<conf::BeaconNodeConf>, ref<bearssl_rand::HmacDrbgContext>)
service.20260820_0700.log-???(0): nimbus_beacon_node::run(ref<beacon_node::BeaconNodecolonObjectType_>, InternalRaisesFuture<void, tuple<futures::CancelledError> >) [clone .constprop.0]
service.20260820_0700.log-???(0): asyncengine::poll
service.20260820_0700.log-???(0): recover_cells_and_proofs_parallel::completeWait(pointer)
service.20260820_0700.log-???(0): 000000007f17074394af
service.20260820_0700.log-???(0): signalHandler
service.20260820_0700.log:SIGSEGV: Illegal storage access. (Attempt to read from nil?)
--
service.20260821_2000.log-???(0): nimbus_beacon_node::handleStartUpCmd(var<conf::BeaconNodeConf>)
service.20260821_2000.log-???(0): nimbus_beacon_node::doRunBeaconNode(var<conf::BeaconNodeConf>, ref<bearssl_rand::HmacDrbgContext>)
service.20260821_2000.log-???(0): nimbus_beacon_node::run(ref<beacon_node::BeaconNodecolonObjectType_>, InternalRaisesFuture<void, tuple<futures::CancelledError> >) [clone .constprop.0]
service.20260821_2000.log-???(0): asyncengine::poll
service.20260821_2000.log-???(0): recover_cells_and_proofs_parallel::completeWait(pointer)
service.20260821_2000.log-???(0): 000000007ff9b27f64af
service.20260821_2000.log-???(0): signalHandler
service.20260821_2000.log:SIGSEGV: Illegal storage access. (Attempt to read from nil?)
--
service.20260822_0300.log-???(0): nimbus_beacon_node::handleStartUpCmd(var<conf::BeaconNodeConf>)
service.20260822_0300.log-???(0): nimbus_beacon_node::doRunBeaconNode(var<conf::BeaconNodeConf>, ref<bearssl_rand::HmacDrbgContext>)
service.20260822_0300.log-???(0): nimbus_beacon_node::run(ref<beacon_node::BeaconNodecolonObjectType_>, InternalRaisesFuture<void, tuple<futures::CancelledError> >) [clone .constprop.0]
service.20260822_0300.log-???(0): asyncengine::poll
service.20260822_0300.log-???(0): recover_cells_and_proofs_parallel::completeWait(pointer)
service.20260822_0300.log-???(0): 000000007fbeb4a6c4af
service.20260822_0300.log-???(0): signalHandler
service.20260822_0300.log:SIGSEGV: Illegal storage access. (Attempt to read from nil?)
```

This turned out to be attributable to #8853, so, reverting it.