### PR TITLE
avoid spurious successful but empty getPtcDuties endpoint results around Gloas fork

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -22,9 +22,6 @@ import
   ./[beacon_chain_db_light_client, beacon_chain_db_quarantine, db_utils,
      filepath]
 
-from ./spec/datatypes/capella import BeaconState
-from ./spec/datatypes/deneb import TrustedSignedBeaconBlock
-
 export
   phase0, altair, eth2_ssz_serialization, eth2_merkleization, kvstore,
   kvstore_sqlite3

--- a/beacon_chain/beacon_chain_file.nim
+++ b/beacon_chain/beacon_chain_file.nim
@@ -5,7 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import results, snappy, stew/[io2, endians2]
 import ./spec/[eth2_ssz_serialization, eth2_merkleization, forks]
@@ -237,7 +237,7 @@ proc init(t: typedesc[Chunk], kind, slot: uint64, plainSize: uint32,
   offset += ChainFileHeaderSize
 
   if len(data) > 0:
-    copyMem(addr dst[offset], unsafeAddr data[0], len(data))
+    copyMem(addr dst[offset], addr data[0], len(data))
     offset += len(data)
 
   footer.store(dst.toOpenArray(offset, offset + ChainFileFooterSize - 1))

--- a/beacon_chain/consensus_object_pools/sync_committee_msg_pool.nim
+++ b/beacon_chain/consensus_object_pools/sync_committee_msg_pool.nim
@@ -12,8 +12,7 @@ import
   stew/shims/hashes,
   eth/p2p/discoveryv5/random2,
   chronicles,
-  ../spec/[crypto, digest, forks],
-  ../spec/datatypes/altair
+  ../spec/[crypto, digest, forks]
 
 export hashes, sets, tables, altair
 

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -387,6 +387,9 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
                         pubkey: value.toPubKey(),
                         validator_index: validator_index,
                         slot: slot))
+            else:
+              # Don't return inaccurate/misleading empty duties
+              return RestApiResponse.jsonError(Http503, StateNotFoundError)
           res
 
       optimistic = node.getShufflingOptimistic(

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -409,7 +409,7 @@ func fromHex*(T: type BlsCurveType, hexStr: string): BlsResult[T] {.inline.} =
     err "bls: cannot parse value"
 
 func `==`*(a, b: ValidatorPubKey | ValidatorSig): bool =
-  equalMem(unsafeAddr a.blob[0], unsafeAddr b.blob[0], sizeof(a.blob))
+  equalMem(addr a.blob[0], addr b.blob[0], sizeof(a.blob))
 
 func isZero*(x: ValidatorPubKey): bool =
   var tmp {.noinit.}: uint64
@@ -429,7 +429,7 @@ template hash*(x: ValidatorPubKey | ValidatorSig): Hash =
   static: doAssert sizeof(Hash) <= x.blob.len div 2
   # We use rough "middle" of blob for the hash, assuming this is where most of
   # the entropy is found
-  cast[ptr Hash](unsafeAddr x.blob[x.blob.len div 2])[]
+  cast[ptr Hash](addr x.blob[x.blob.len div 2])[]
 
 # Comparison/Sorting
 # ----------------------------------------------------------------------

--- a/beacon_chain/spec/digest.nim
+++ b/beacon_chain/spec/digest.nim
@@ -132,7 +132,7 @@ template hash*(x: Eth2Digest): Hash =
   ## Hash for digests for Nim hash tables
   # digests are already good hashes
   var h {.noinit.}: Hash
-  copyMem(addr h, unsafeAddr x.data[0], static(sizeof(Hash)))
+  copyMem(addr h, addr x.data[0], static(sizeof(Hash)))
   h
 
 func `==`*(a, b: Eth2Digest): bool =
@@ -141,7 +141,7 @@ func `==`*(a, b: Eth2Digest): bool =
   else:
     # nimcrypto uses a constant-time comparison for all MDigest types which for
     # Eth2Digest is unnecessary - the type should never hold a secret!
-    equalMem(unsafeAddr a.data[0], unsafeAddr b.data[0], sizeof(a.data))
+    equalMem(addr a.data[0], addr b.data[0], sizeof(a.data))
 
 func isZero*(x: Eth2Digest): bool =
   var tmp {.noinit.}: uint64

--- a/beacon_chain/spec/light_client_sync.nim
+++ b/beacon_chain/spec/light_client_sync.nim
@@ -5,7 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import
   stew/[bitops2, bitseqs, objects],
@@ -145,9 +145,9 @@ proc validate_light_client_update*(
   # Verify sync committee aggregate signature
   let sync_committee =
     if signature_period == store_period:
-      unsafeAddr store.current_sync_committee
+      addr store.current_sync_committee
     else:
-      unsafeAddr store.next_sync_committee
+      addr store.next_sync_committee
   let
     fork_version_slot = max(update.signature_slot, 1.Slot) - 1
     fork_version = cfg.forkVersionAtEpoch(fork_version_slot.epoch)

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -168,7 +168,7 @@ proc check_proposer_slashing*(
   if header_1.proposer_index >= state.validators.lenu64:
     return err("check_proposer_slashing: invalid proposer index")
 
-  let proposer = unsafeAddr state.validators[header_1.proposer_index]
+  let proposer = addr state.validators[header_1.proposer_index]
   if not is_slashable_validator(proposer[], get_current_epoch(state)):
     return err("check_proposer_slashing: slashed proposer")
 
@@ -439,7 +439,7 @@ proc check_voluntary_exit*(
   if voluntary_exit.validator_index >= state.validators.lenu64:
     return err("Exit: invalid validator index")
 
-  let validator = unsafeAddr state.validators[voluntary_exit.validator_index]
+  let validator = addr state.validators[voluntary_exit.validator_index]
 
   # Verify the validator is active
   if not is_active_validator(validator[], get_current_epoch(state)):

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -24,8 +24,6 @@ const
   largeRequestsTimeout = 6.minutes  # Downloading large items such as states.
   smallRequestsTimeout = 30.seconds # Downloading smaller items such as blocks and deposit snapshots.
 
-from ./spec/datatypes/deneb import asSigVerified, shortLog
-
 type
   TrustedNodeSyncKind* {.pure.} = enum
     TrustedBlockRoot,

--- a/tests/test_keymanager_api.nim
+++ b/tests/test_keymanager_api.nim
@@ -142,7 +142,7 @@ const
   # vcSecretsDir = vcDataDir / "secrets"
 
 func specifiedFeeRecipient(x: int): Eth1Address =
-  copyMem(addr result, unsafeAddr x, sizeof x)
+  copyMem(addr result, addr x, sizeof x)
 
 func contains*(keylist: openArray[KeystoreInfo], key: ValidatorPubKey): bool =
   for item in keylist:


### PR DESCRIPTION
Otherwise there's a gap (usually but not always one slot) after there are, in theory, Gloas PTC duties to compute but no Gloas state from which to compute them.