### PR TITLE
sync: reset queue when failed request empties head

### DIFF
--- a/beacon_chain/sync/sync_queue.nim
+++ b/beacon_chain/sync/sync_queue.nim
@@ -758,6 +758,15 @@ proc push*[T](sq: SyncQueue[T], requests: openArray[SyncRequest[T]]) =
       continue
     sq.del(pos)
 
+    if pos.qindex == 0 and len(sq.requests[0].requests) == 0:
+      debug "Failed head request left no active requests, resetting queue",
+            request = request,
+            sync_ident = sq.ident,
+            direction = sq.kind,
+            topics = "syncman"
+      sq.clearAndWakeup()
+      return
+
 proc push*[T](sq: SyncQueue[T], sr: SyncRequest[T]) =
   ## Push single failed request back to queue.
   sq.push([sr])

--- a/tests/test_sync_manager.nim
+++ b/tests/test_sync_manager.nim
@@ -130,6 +130,26 @@ proc setupVerifier(
 
   (collector(aq), verifier(aq))
 
+func acceptingLivenessVerifier(): BlockVerifier =
+  proc verify(
+      signedBlock: ForkedSignedBeaconBlock,
+      blobs: Opt[BlobSidecars],
+      maybeFinalized: bool
+  ): Future[Result[void, VerifierError]] {.
+    async: (raises: [CancelledError], raw: true).} =
+    discard signedBlock
+    discard blobs
+    discard maybeFinalized
+
+    let fut =
+      Future[Result[void, VerifierError]].Raising([CancelledError]).init()
+
+    fut.complete(Result[void, VerifierError].ok())
+    fut
+
+  verify
+
+
 suite "SyncManager test suite":
   for kind in [SyncQueueKind.Forward, SyncQueueKind.Backward]:
     asyncTest "[SyncQueue# & " & $kind & "] Smoke [single peer] test":
@@ -409,6 +429,110 @@ suite "SyncManager test suite":
         sq.push(r13)
 
       await noCancel wait(verifier.verifier, 2.seconds)
+
+    asyncTest "[SyncQueue# & " & $kind &
+              "] Failed sole head request wakes blocked later pushes":
+      # A failed sole request for the head range must not leave successful
+      # later-range pushes blocked indefinitely. Those pushes need to return
+      # so their workers can release their peers and retry the missing head.
+      let
+        sq =
+          case kind
+          of SyncQueueKind.Forward:
+            SyncQueue.init(
+              SomeTPeer,
+              kind,
+              Slot(0),
+              Slot(127),
+              32'u64,
+              1, # one request per range
+              2,
+              getStaticSlotCb(Slot(0)),
+              acceptingLivenessVerifier(),
+              testforkAtEpoch
+            )
+          of SyncQueueKind.Backward:
+            SyncQueue.init(
+              SomeTPeer,
+              kind,
+              Slot(127),
+              Slot(0),
+              32'u64,
+              1, # one request per range
+              2,
+              getStaticSlotCb(Slot(127)),
+              acceptingLivenessVerifier(),
+              testforkAtEpoch
+            )
+
+        peer0 = SomeTPeer.init("head")
+        peer1 = SomeTPeer.init("later-1")
+        peer2 = SomeTPeer.init("later-2")
+        peer3 = SomeTPeer.init("later-3")
+
+        r0 = sq.pop(Slot(127), peer0)
+        r1 = sq.pop(Slot(127), peer1)
+        r2 = sq.pop(Slot(127), peer2)
+        r3 = sq.pop(Slot(127), peer3)
+
+        d1 = createChain(r1.data)
+        d2 = createChain(r2.data)
+        d3 = createChain(r3.data)
+
+        startSlot =
+          case kind
+          of SyncQueueKind.Forward:
+            Slot(0)
+          of SyncQueueKind.Backward:
+            Slot(127)
+
+      check:
+        not r0.isEmpty()
+        not r1.isEmpty()
+        not r2.isEmpty()
+        not r3.isEmpty()
+
+      let
+        f1 = sq.push(r1, d1, Opt.none(seq[BlobSidecars]))
+        f2 = sq.push(r2, d2, Opt.none(seq[BlobSidecars]))
+        f3 = sq.push(r3, d3, Opt.none(seq[BlobSidecars]))
+
+      # Give all speculative pushes time to reach queue backpressure.
+      await sleepAsync(20.milliseconds)
+
+      check:
+        f1.finished == false
+        f2.finished == false
+        f3.finished == false
+
+      # The sole request serving the queue head fails.
+      sq.push(r0)
+
+      # Correct behavior: queue reset/wakeup lets speculative pushes return.
+      await sleepAsync(20.milliseconds)
+
+      let speculativePushesReleased =
+        f1.finished and f2.finished and f3.finished
+
+      check speculativePushesReleased
+
+      # Keep RED execution bounded on the currently vulnerable implementation.
+      if not speculativePushesReleased:
+        sq.clearAndWakeup()
+
+      await noCancel f1
+      await noCancel f2
+      await noCancel f3
+
+      # Recovery must retry the same head range rather than skipping it.
+      let refill = sq.pop(Slot(127), peer0)
+
+      check:
+        refill.data == r0.data
+        sq.outSlot == startSlot
+
+      sq.clearAndWakeup()
+
 
     asyncTest "[SyncQueue# & " & $kind & "] Invalid block [3 peers] test":
       # This scenario performs test for 2 cases.


### PR DESCRIPTION
## Summary

Fix a SyncQueue liveness condition where removing a failed request can leave
the current queue head with no active requests while later workers remain
blocked in `push()`.

Those blocked workers can continue holding their acquired peers. If all
remaining peers are held this way, no peer is available to refill the missing
head range, preventing synchronization from making further progress.

When removing a failed request empties the current queue head,
`clearAndWakeup()` resets the speculative queue and wakes blocked pushes. This
lets those workers return and release their peers so the missing head range can
be requested again.

## Regression tests

Adds forward and backward tests covering the case where:

- the sole request at the queue head fails;
- later requests have already completed;
- later `push()` calls are blocked behind the head;
- removing the failed head must release those blocked pushes.

Without the production change, both new tests fail.

With the change on current `unstable`:

- `tests/test_sync_manager.nim`: 27/27 pass
- repeated execution of the same test binary: 30/30 pass

The same fix and regression-test pair was also validated on Nimbus v26.7.0.

## Real-world validation

The issue was encountered while testing Nimbus on a private Ethereum PoS
network.

A patched v26 beacon node was subsequently tested from fresh consensus and
execution databases with a hard limit of 3 consensus peers. It completed
approximately 1.05 million slots of historical backfill while continuing to
follow the live chain, matched an independent Lighthouse node at finality, and
remained healthy for more than 2.5 hours after backfill completion.

The historical INFO logs do not contain enough detail to prove the exact
initiating request from the original incident, so this PR does not claim that
exact historical trigger. The regression tests target the generic liveness
condition reproduced independently.
