### PR TITLE
fix: write generated jwt.hex with 0600 permissions

### DIFF
--- a/beacon_chain/spec/engine_authentication.nim
+++ b/beacon_chain/spec/engine_authentication.nim
@@ -18,6 +18,7 @@ import
   stew/byteutils
 
 from std/os import `/`, fileExists
+from ../filepath import secureWriteFile
 
 export rand, results
 
@@ -109,12 +110,12 @@ proc checkJwtSecret*(
       return loadJwtSecretFile(InputFile jwtSecretPath)
     var newSecret: JwtSharedKey
     rng(distinctBase newSecret)
-    try:
-      writeFile(jwtSecretPath, distinctBase(newSecret).to0xHex())
-    except IOError as exc:
+    let writeRes = secureWriteFile(jwtSecretPath, distinctBase(newSecret).to0xHex())
+    if writeRes.isErr():
       # Allow continuing to run, though this is effectively fatal for a merge
       # client using authentication. This keeps it lower-risk initially.
-      warn "Could not write JWT secret to data directory", jwtSecretPath, err = exc.msg
+      warn "Could not write JWT secret to data directory", jwtSecretPath,
+        err = $writeRes.error
 
     notice "JWT secret generated", jwtSecretPath
 

--- a/beacon_chain/spec/engine_authentication.nim
+++ b/beacon_chain/spec/engine_authentication.nim
@@ -15,7 +15,8 @@ import
   confutils/defs,
   nimcrypto/[hmac, utils, sha2],
   results,
-  stew/byteutils
+  stew/byteutils,
+  stew/io2
 
 from std/os import `/`, fileExists
 from ../filepath import secureWriteFile
@@ -115,7 +116,7 @@ proc checkJwtSecret*(
       # Allow continuing to run, though this is effectively fatal for a merge
       # client using authentication. This keeps it lower-risk initially.
       warn "Could not write JWT secret to data directory", jwtSecretPath,
-        err = $writeRes.error
+        errorMsg = ioErrorMsg(writeRes.error), errorCode = $writeRes.error
 
     notice "JWT secret generated", jwtSecretPath
 


### PR DESCRIPTION
When `--jwt-secret` is omitted, `checkJwtSecret` generates `dataDir/jwt.hex` with `std/os.writeFile`. That uses the process umask (typically 0644). Anyone who can read the data directory can mint Engine API JWTs.

Validator keystores already go through `secureWriteFile` (0600 on Unix, user-only ACL on Windows). Use the same helper for the generated JWT secret. Failure still warns and continues, same as today.

#7533 tried this against `stable` and the bot closed it. This is the current `unstable` generate path.

## Test

Static: `secureWriteFile` is `writeFile(..., 0o600)` in `beacon_chain/filepath.nim`. The old call is two-arg `writeFile` (umask default). I do not have a Nim toolchain here to run `tests/test_el_conf`.