### PR TITLE
Validate bid gas limit against the payload at bid.parent_block_hash

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1128,6 +1128,20 @@ proc loadExecutionAndParentBlockHash*(dag: ChainDAGRef, bid: BlockId):
     else:
       (Opt.some ZERO_HASH, Opt.some ZERO_HASH)
 
+proc loadExecutionGasLimit*(dag: ChainDAGRef, bid: BlockId): Opt[uint64] =
+  ## The `gas_limit` of the execution payload committed to by the block, i.e.
+  ## the bid's `gas_limit` post-Gloas (the envelope must match the bid).
+  let blockData = dag.getForkedBlock(bid).valueOr:
+    return Opt.none(uint64)
+
+  withBlck(blockData):
+    when consensusFork >= ConsensusFork.Gloas:
+      Opt.some forkyBlck.message.body.signed_execution_payload_bid.message.gas_limit
+    elif consensusFork in ConsensusFork.Bellatrix .. ConsensusFork.Fulu:
+      Opt.some forkyBlck.message.body.execution_payload.gas_limit
+    else:
+      Opt.none(uint64)
+
 proc loadExecutionAndParentBlockHash*(dag: ChainDAGRef, blck: BlockRef):
     tuple[blockHash: Opt[Eth2Digest], parentHash: Opt[Eth2Digest]] =
   if blck.executionBlockHash.isNone() or blck.executionParentHash.isNone():
@@ -1146,6 +1160,26 @@ proc loadExecutionAndParentBlockHash*(dag: ChainDAGRef, blck: BlockRef):
         cur = cur.parent
 
   (blck.executionBlockHash, blck.executionParentHash)
+
+proc loadExecutionParent*(dag: ChainDAGRef, blck: BlockRef): Opt[BlockRef] =
+  ## The ancestor whose execution payload `blck` builds on, i.e. the block
+  ## whose payload `block_hash` equals `blck`'s payload `parent_block_hash`.
+  ## Unlike `executionParent`, this loads the hashes of ancestors on demand.
+  let (_, parentHash) = dag.loadExecutionAndParentBlockHash(blck)
+  if parentHash.isNone() or isNil(blck.parent):
+    return Opt.none(BlockRef)
+  if parentHash.get().isZero():
+    return Opt.some(blck.parent)
+
+  var cur = blck.parent
+  for _ in 0 ..< EXECUTION_PARENT_MAX_DEPTH:
+    if isNil(cur):
+      break
+    let (blockHash, _) = dag.loadExecutionAndParentBlockHash(cur)
+    if blockHash.isSome() and blockHash.get() == parentHash.get():
+      return Opt.some(cur)
+    cur = cur.parent
+  Opt.none(BlockRef)
 
 proc applyBlock(
     dag: ChainDAGRef, state: var ForkedHashedBeaconState, bid: BlockId,

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1161,26 +1161,6 @@ proc loadExecutionAndParentBlockHash*(dag: ChainDAGRef, blck: BlockRef):
 
   (blck.executionBlockHash, blck.executionParentHash)
 
-proc loadExecutionParent*(dag: ChainDAGRef, blck: BlockRef): Opt[BlockRef] =
-  ## The ancestor whose execution payload `blck` builds on, i.e. the block
-  ## whose payload `block_hash` equals `blck`'s payload `parent_block_hash`.
-  ## Unlike `executionParent`, this loads the hashes of ancestors on demand.
-  let (_, parentHash) = dag.loadExecutionAndParentBlockHash(blck)
-  if parentHash.isNone() or isNil(blck.parent):
-    return Opt.none(BlockRef)
-  if parentHash.get().isZero():
-    return Opt.some(blck.parent)
-
-  var cur = blck.parent
-  for _ in 0 ..< EXECUTION_PARENT_MAX_DEPTH:
-    if isNil(cur):
-      break
-    let (blockHash, _) = dag.loadExecutionAndParentBlockHash(cur)
-    if blockHash.isSome() and blockHash.get() == parentHash.get():
-      return Opt.some(cur)
-    cur = cur.parent
-  Opt.none(BlockRef)
-
 proc applyBlock(
     dag: ChainDAGRef, state: var ForkedHashedBeaconState, bid: BlockId,
     cache: var StateCache, info: var ForkedEpochInfo,

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -2028,9 +2028,25 @@ proc validateExecutionPayloadBid*(
       # ... `is_gas_limit_target_compatible(parent_gas_limit, bid.gas_limit,
       # proposer_preferences.target_gas_limit)` is True, where
       # `parent_gas_limit` is the `gas_limit` of that execution payload.
+      #
+      # The execution payload identified by `bid.parent_block_hash` is either
+      # the parent block's own payload (`Timely`) or the payload the parent
+      # block builds on (`Withheld`), which can differ from the parent block's
+      # bid `gas_limit`.
+      let parentPayloadBlck =
+        case payloadAvailability
+        of PayloadAvailability.Timely:
+          parentBlck
+        of PayloadAvailability.Withheld:
+          dag.loadExecutionParent(parentBlck).valueOr:
+            return errIgnore(
+              "ExecutionPayloadBid: parent execution payload block unknown")
+      let parentGasLimit =
+        dag.loadExecutionGasLimit(parentPayloadBlck.bid).valueOr:
+          return errIgnore(
+            "ExecutionPayloadBid: parent execution payload gas limit unknown")
       if not is_gas_limit_target_compatible(
-          forkyState.data.latest_execution_payload_bid.gas_limit,
-          bid.gas_limit, seenPref.target_gas_limit):
+          parentGasLimit, bid.gas_limit, seenPref.target_gas_limit):
         return errIgnore("ExecutionPayloadBid: gas limit not target-compatible")
 
       # [IGNORE] bid.slot is the current slot or the next slot

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -2030,17 +2030,12 @@ proc validateExecutionPayloadBid*(
       # `parent_gas_limit` is the `gas_limit` of that execution payload.
       #
       # The execution payload identified by `bid.parent_block_hash` is either
-      # the parent block's own payload (`Timely`) or the payload the parent
-      # block builds on (`Withheld`), which can differ from the parent block's
-      # bid `gas_limit`.
+      # the parent block's own payload or one the parent block builds on
+      # (withheld), whose `gas_limit` can differ from the parent block's bid.
       let parentPayloadBlck =
-        case payloadAvailability
-        of PayloadAvailability.Timely:
-          parentBlck
-        of PayloadAvailability.Withheld:
-          dag.loadExecutionParent(parentBlck).valueOr:
-            return errIgnore(
-              "ExecutionPayloadBid: parent execution payload block unknown")
+        dag.executionParent(parentBlck, bid.parent_block_hash).valueOr:
+          return errIgnore(
+            "ExecutionPayloadBid: parent execution payload block unknown")
       let parentGasLimit =
         dag.loadExecutionGasLimit(parentPayloadBlck.bid).valueOr:
           return errIgnore(


### PR DESCRIPTION
## What

`validateExecutionPayloadBid` derived `parent_gas_limit` from `dag.headState.latest_execution_payload_bid.gas_limit` — the head block's own bid — regardless of which payload the bid builds on. The spec keys the check on the payload the bid actually extends:

```python
parent_gas_limit = seen.execution_payloads[bid.parent_block_hash].gas_limit
```
(https://github.com/ethereum/consensus-specs/blob/a670e0193446474bb1775ec94a93ca6fbaa11a89/specs/gloas/p2p-interface.md#L995-L1000)

A bid with `parent_block_root = head` and `parent_block_hash = head_bid.parent_block_hash` (head payload treated as withheld — permitted by `is_bid_compatible_with_head` when `should_build_on_full` is false) must be checked against the grandparent payload's gas limit. Whenever the gas limit is moving, that differs from the head bid's gas limit by one EIP-1559 step, so a spec-correct bid was dropped with `gas limit not target-compatible` — on gossip and via `POST /eth/v1/beacon/execution_payload_bids` (same path).

This PR resolves the block carrying the payload identified by `bid.parent_block_hash` via the existing `dag.executionParent(parentBlck, bid.parent_block_hash)` (same lookup `validateBeaconBlockGloas` uses), and uses that block's committed gas limit (`loadExecutionGasLimit`: the bid's `gas_limit` post-Gloas, the payload's pre-Gloas). Envelopes must match their bid's `gas_limit`, so the bid value is the payload value.

## Why

Seen on glamsterdam-devnet-8 (gas limit ramping under EIP-8261). Slot 85165: payload at 85163 had gas limit 199411976, payload at 85164 (head) had 199606713, target 200000000. A builder's parent-empty bid carried 199606713 = 199411976 + 199411976/1024 − 1, correct for the payload it builds on; comparing against the head bid (199606713) instead makes it look like it failed to step toward the target.

Same class of bug was found in prysm (fixed in https://github.com/OffchainLabs/prysm/pull/17405), lighthouse (https://github.com/sigp/lighthouse/pull/9905) and grandine; lodestar and teku are correct. The spec gossip test vectors don't cover empty-head bids yet (all cases use the head's own payload as `parent_block_hash`), a vector PR is in progress.

## Notes

- Builds `nimbus_beacon_node` locally; there is no existing unit-test harness for `validateExecutionPayloadBid`, happy to add one if you can point me at the preferred fixture.
