### PR TITLE
config: load networking overrides from RuntimeConfig

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -887,6 +887,12 @@ AllTests-mainnet
 + validateBlocks(SyncRange, SyncResponseItem, GloasColumnSidecarResponseRecord) [node] test  OK
 + validateBlocks(SyncRange, SyncResponseItem, GloasColumnSidecarResponseRecord) [supernode]  OK
 ```
+## Runtime network configuration
+```diff
++ custom networking values and quoted Hash32 parse                                           OK
++ defaults preserve compiled networking values                                               OK
++ networking guardrails reject invalid values                                                OK
+```
 ## Serialization/deserialization [Beacon Node] [Preset: mainnet]
 ```diff
 + Deserialization test vectors                                                               OK
@@ -1236,6 +1242,7 @@ AllTests-mainnet
 + should register sync committee duties                                                      OK
 + should subscribe to all subnets when flag is enabled                                       OK
 + should track PTC duties in slot bitmaps                                                    OK
++ should use runtime stability subnet parameters                                             OK
 ```
 ## toPeerAddr port handling
 ```diff

--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -889,7 +889,7 @@ AllTests-mainnet
 ```
 ## Runtime network configuration
 ```diff
-+ custom networking values and quoted Hash32 parse                                           OK
++ custom networking values                                           OK
 + defaults preserve compiled networking values                                               OK
 + networking guardrails reject invalid values                                                OK
 ```

--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -889,7 +889,7 @@ AllTests-mainnet
 ```
 ## Runtime network configuration
 ```diff
-+ custom networking values                                           OK
++ custom networking values                                                                   OK
 + defaults preserve compiled networking values                                               OK
 + networking guardrails reject invalid values                                                OK
 ```

--- a/beacon_chain/beacon_node_light_client.nim
+++ b/beacon_chain/beacon_node_light_client.nim
@@ -56,7 +56,8 @@ proc initLightClient*(
         discard await node.elManager.newExecutionPayload(signedEnvelope.message)
 
     lightBlockProcessor = initLightBlockProcessor(
-      cfg.timeParams, getBeaconTime, lightBlockHandler, lightEnvelopeHandler)
+      cfg.timeParams, cfg.gossipClockDisparityDuration,
+      getBeaconTime, lightBlockHandler, lightEnvelopeHandler)
 
     shouldInhibitSync = func(): bool =
       if isNil(node.syncOverseer):

--- a/beacon_chain/consensus_object_pools/execution_payload_pool.nim
+++ b/beacon_chain/consensus_object_pools/execution_payload_pool.nim
@@ -77,7 +77,7 @@ proc addBid*(
 
   # Bids expire after their slot has passed
   pool.prune(beforeSlot =
-    (wallTime - MAXIMUM_GOSSIP_CLOCK_DISPARITY).slotOrZero(pool.dag.timeParams))
+    (wallTime - pool.dag.cfg.gossipClockDisparityDuration).slotOrZero(pool.dag.timeParams))
 
   let slotData = addr pool.slotBids.mgetOrPut(bid.slot, default(SlotBids))
 

--- a/beacon_chain/gossip_processing/block_processor_light_client.nim
+++ b/beacon_chain/gossip_processing/block_processor_light_client.nim
@@ -32,6 +32,7 @@ type
 
   LightBlockProcessor* = ref object
     timeParams: TimeParams
+    gossipClockDisparity: Duration
     getBeaconTime: GetBeaconTimeFn
     lightBlockVerifier: LightBlockVerifier
     lightEnvelopeVerifier: LightEnvelopeVerifier
@@ -39,11 +40,13 @@ type
 
 proc initLightBlockProcessor*(
     timeParams: TimeParams,
+    gossipClockDisparity: Duration,
     getBeaconTime: GetBeaconTimeFn,
     lightBlockVerifier: LightBlockVerifier,
     lightEnvelopeVerifier: LightEnvelopeVerifier): LightBlockProcessor =
   LightBlockProcessor(
     timeParams: timeParams,
+    gossipClockDisparity: gossipClockDisparity,
     getBeaconTime: getBeaconTime,
     lightBlockVerifier: lightBlockVerifier,
     lightEnvelopeVerifier: lightEnvelopeVerifier)
@@ -54,7 +57,7 @@ proc validateBeaconBlock(
     wallTime: BeaconTime): Result[void, ValidationError] =
   ## Minimally validate a block for potential relevance.
   if not (signed_beacon_block.message.slot <=
-      (wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY).slotOrZero(self.timeParams)):
+      (wallTime + self.gossipClockDisparity).slotOrZero(self.timeParams)):
     return errIgnore("BeaconBlock: slot too high")
 
   if not signed_beacon_block.message.is_execution_block():
@@ -137,7 +140,7 @@ proc validateExecutionPayload(
   ## Minimally validate an envelope for potential relevance.
   template envelope: untyped = signed_execution_payload_envelope.message
   if not (envelope.slot <=
-      (wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY).slotOrZero(self.timeParams)):
+      (wallTime + self.gossipClockDisparity).slotOrZero(self.timeParams)):
     return errIgnore("ExecutionPayload: slot too high")
 
   if envelope.payload.block_hash.isZero:

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -123,16 +123,16 @@ func check_attestation_block(
   ok()
 
 func check_propagation_slot_range(
-    timeParams: TimeParams,
+    cfg: RuntimeConfig,
     msgSlot: Slot,
     wallTime: BeaconTime): Result[void, ValidationError] =
   let futureSlot =
-    (wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY).toSlot(timeParams)
+    (wallTime + cfg.gossipClockDisparityDuration).toSlot(cfg.timeParams)
   if not futureSlot.afterGenesis or msgSlot > futureSlot.slot:
     return errIgnore("Attestation slot in the future")
 
   let pastSlot =
-    (wallTime - MAXIMUM_GOSSIP_CLOCK_DISPARITY).toSlot(timeParams)
+    (wallTime - cfg.gossipClockDisparityDuration).toSlot(cfg.timeParams)
   if not pastSlot.afterGenesis:
     return ok()
 
@@ -153,16 +153,16 @@ func check_propagation_slot_range(
   ok()
 
 func check_slot_exact(
-    timeParams: TimeParams,
+    cfg: RuntimeConfig,
     msgSlot: Slot,
     wallTime: BeaconTime): Result[Slot, ValidationError] =
   let futureSlot =
-    (wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY).toSlot(timeParams)
+    (wallTime + cfg.gossipClockDisparityDuration).toSlot(cfg.timeParams)
   if not futureSlot.afterGenesis or msgSlot > futureSlot.slot:
     return errIgnore("Sync committee slot in the future")
 
   let pastSlot =
-    (wallTime - MAXIMUM_GOSSIP_CLOCK_DISPARITY).toSlot(timeParams)
+    (wallTime - cfg.gossipClockDisparityDuration).toSlot(cfg.timeParams)
   if pastSlot.afterGenesis and msgSlot < pastSlot.slot:
     return errIgnore("Sync committee slot in the past")
 
@@ -526,7 +526,7 @@ proc validateDataColumnSidecar*(
   # `block_header.slot <= current_slot`(a client MAY queue future sidecars for
   # processing at the appropriate slot).
   if not (block_header.slot <=
-      (wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY).slotOrZero(dag.timeParams)):
+      (wallTime + dag.cfg.gossipClockDisparityDuration).slotOrZero(dag.timeParams)):
     return errIgnore("DataColumnSidecar: slot too high")
 
   # [IGNORE] The sidecar is from a slot greater than the latest
@@ -761,7 +761,7 @@ proc validateBeaconBlock*(
   # signed_beacon_block.message.slot <= current_slot (a client MAY queue future
   # blocks for processing at the appropriate slot).
   if not (signed_beacon_block.message.slot <=
-      (wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY).slotOrZero(dag.timeParams)):
+      (wallTime + dag.cfg.gossipClockDisparityDuration).slotOrZero(dag.timeParams)):
     return errIgnore("BeaconBlock: slot too high")
 
   # [IGNORE] The block is from a slot greater than the latest finalized slot --
@@ -938,7 +938,7 @@ proc validateExecutionPayload*(
 
   # No matching block can exist: blocks [IGNORE] future slots.
   if not (envelope.slot <=
-      (wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY).slotOrZero(dag.timeParams)):
+      (wallTime + dag.cfg.gossipClockDisparityDuration).slotOrZero(dag.timeParams)):
     return errIgnore("ExecutionPayload: slot too high")
 
   # [IGNORE] The envelope's block root `envelope.beacon_block_root` has been
@@ -1100,7 +1100,7 @@ proc validateAttestation*(
   # [IGNORE]
   # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.2/specs/deneb/p2p-interface.md#beacon_attestation_subnet_id
   # modifies this for Deneb and newer forks.
-  ?pool.dag.timeParams.check_propagation_slot_range(slot, wallTime)
+  ?pool.dag.cfg.check_propagation_slot_range(slot, wallTime)
 
   # The block being voted for (attestation.data.beacon_block_root) has been seen
   # (via both gossip and non-gossip sources) (a client MAY queue attestations
@@ -1289,7 +1289,7 @@ proc validateAggregate*(
   #
   # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.2/specs/deneb/p2p-interface.md#beacon_aggregate_and_proof
   # modifies this for Deneb and newer forks.
-  ?pool.dag.timeParams.check_propagation_slot_range(slot, wallTime)
+  ?pool.dag.cfg.check_propagation_slot_range(slot, wallTime)
 
   let aggregator_index = ValidatorIndex.init(aggregate_and_proof.aggregator_index).valueOr:
     return pool.checkedReject("Aggregate: invalid aggregator index")
@@ -1635,7 +1635,7 @@ proc validateSyncCommitteeMessage*(
     # [IGNORE] The message's slot is for the current slot (with a
     # `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance), i.e.
     # `sync_committee_message.slot == current_slot`.
-    let v = dag.timeParams.check_slot_exact(msg.slot, wallTime)
+    let v = dag.cfg.check_slot_exact(msg.slot, wallTime)
     if v.isErr():
       return err(v.error())
 
@@ -1724,7 +1724,7 @@ proc validateContribution*(
     # [IGNORE] The contribution's slot is for the current slot
     # (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance)
     # i.e. contribution.slot == current_slot.
-    let v = dag.timeParams.check_slot_exact(
+    let v = dag.cfg.check_slot_exact(
       msg.message.contribution.slot, wallTime)
     if v.isErr():  # [IGNORE]
       return err(v.error())
@@ -1886,7 +1886,7 @@ proc validateLightClientFinalityUpdate*(
         forkyFinalityUpdate.signature_slot
       else:
         GENESIS_SLOT
-    currentTime = wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY
+    currentTime = wallTime + dag.cfg.gossipClockDisparityDuration
     forwardTime = signature_slot
       .light_client_finality_update_time(dag.timeParams)
   if currentTime < forwardTime:
@@ -1924,7 +1924,7 @@ proc validateLightClientOptimisticUpdate*(
         forkyOptimisticUpdate.signature_slot
       else:
         GENESIS_SLOT
-    currentTime = wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY
+    currentTime = wallTime + dag.cfg.gossipClockDisparityDuration
     forwardTime = signature_slot
       .light_client_optimistic_update_time(dag.timeParams)
   if currentTime < forwardTime:
@@ -2109,7 +2109,7 @@ proc validatePayloadAttestationMessage*(
   # [IGNORE] The message's slot is for the current slot (with a
   # `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance), i.e `data.slot == current_slot`.
   block:
-    let v = dag.timeParams.check_slot_exact(data.slot, wallTime)
+    let v = dag.cfg.check_slot_exact(data.slot, wallTime)
     if v.isErr():
       return err(v.error())
 
@@ -2291,7 +2291,7 @@ proc validateInclusionList*(
   # `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance), i.e.
   # `message.slot == current_slot`.
   block:
-    let v = dag.timeParams.check_slot_exact(message.slot, wallTime)
+    let v = dag.cfg.check_slot_exact(message.slot, wallTime)
     if v.isErr():
       return err(v.error())
 

--- a/beacon_chain/gossip_processing/light_client_processor.nim
+++ b/beacon_chain/gossip_processing/light_client_processor.nim
@@ -509,7 +509,7 @@ func toValidationError(
             forkyObject.signature_slot
           else:
             GENESIS_SLOT
-        currentTime = wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY
+        currentTime = wallTime + self.cfg.gossipClockDisparityDuration
         forwardTime = signature_slot
           .light_client_finality_update_time(self.cfg.timeParams)
       if currentTime < forwardTime:

--- a/beacon_chain/networking/peer_protocol.nim
+++ b/beacon_chain/networking/peer_protocol.nim
@@ -144,7 +144,7 @@ proc checkStatusMsg(state: PeerSyncNetworkState, status: StatusMsg | StatusMsgV2
   let
     dag = state.dag
     wallSlot = (
-      state.getBeaconTime() + MAXIMUM_GOSSIP_CLOCK_DISPARITY
+      state.getBeaconTime() + state.cfg.gossipClockDisparityDuration
     ).slotOrZero(state.cfg.timeParams)
 
   if status.finalizedEpoch > status.headSlot.epoch:

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -645,7 +645,10 @@ proc initFullNode(
   let
     consensusManager = ConsensusManager.new(
       dag, attestationPool, quarantine, node.elManager,
-      ActionTracker.init(node.network.nodeId, config.subscribeAllSubnets),
+      ActionTracker.init(
+        node.network.nodeId, config.subscribeAllSubnets,
+        dag.cfg.EPOCHS_PER_SUBNET_SUBSCRIPTION,
+        dag.cfg.SUBNETS_PER_NODE),
       node.dynamicFeeRecipientsStore, config.validatorsDir,
       config.defaultFeeRecipient, config.suggestedGasLimit)
     batchVerifier = BatchVerifier.new(rng, taskpool)

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -102,7 +102,8 @@ proc runLightClient*(
         discard await elManager.newExecutionPayload(signedEnvelope.message)
 
     lightBlockProcessor = initLightBlockProcessor(
-      cfg.timeParams, getBeaconTime, lightBlockHandler, lightEnvelopeHandler)
+      cfg.timeParams, cfg.gossipClockDisparityDuration,
+      getBeaconTime, lightBlockHandler, lightEnvelopeHandler)
 
     lightClient = createLightClient(
       network, rng, config, cfg, forkDigests, getBeaconTime,

--- a/beacon_chain/rpc/rest_config_api.nim
+++ b/beacon_chain/rpc/rest_config_api.nim
@@ -287,21 +287,21 @@ proc installConfigApiHandlers*(router: var RestRouter, node: BeaconNode) =
           MAX_PAYLOAD_SIZE:
             Base10.toString(MAX_PAYLOAD_SIZE),
           MAX_REQUEST_BLOCKS:
-            Base10.toString(MAX_REQUEST_BLOCKS),
+            Base10.toString(cfg.MAX_REQUEST_BLOCKS),
           EPOCHS_PER_SUBNET_SUBSCRIPTION:
-            Base10.toString(EPOCHS_PER_SUBNET_SUBSCRIPTION),
+            Base10.toString(cfg.EPOCHS_PER_SUBNET_SUBSCRIPTION),
           MIN_EPOCHS_FOR_BLOCK_REQUESTS:
             Base10.toString(cfg.MIN_EPOCHS_FOR_BLOCK_REQUESTS),
           ATTESTATION_PROPAGATION_SLOT_RANGE:
             Base10.toString(ATTESTATION_PROPAGATION_SLOT_RANGE),
           MAXIMUM_GOSSIP_CLOCK_DISPARITY:
-            Base10.toString(MAXIMUM_GOSSIP_CLOCK_DISPARITY.milliseconds.uint64),
+            Base10.toString(cfg.MAXIMUM_GOSSIP_CLOCK_DISPARITY),
           MESSAGE_DOMAIN_INVALID_SNAPPY:
             to0xHex(MESSAGE_DOMAIN_INVALID_SNAPPY),
           MESSAGE_DOMAIN_VALID_SNAPPY:
             to0xHex(MESSAGE_DOMAIN_VALID_SNAPPY),
           SUBNETS_PER_NODE:
-            Base10.toString(SUBNETS_PER_NODE),
+            Base10.toString(cfg.SUBNETS_PER_NODE),
           ATTESTATION_SUBNET_COUNT:
             Base10.toString(ATTESTATION_SUBNET_COUNT),
           ATTESTATION_SUBNET_EXTRA_BITS:

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -172,7 +172,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
                                            $epoch.error())
         let
           res = epoch.get()
-          wallTime = node.beaconClock.now() + MAXIMUM_GOSSIP_CLOCK_DISPARITY
+          wallTime = node.beaconClock.now() + node.dag.cfg.gossipClockDisparityDuration
           wallEpoch = wallTime.slotOrZero(node.dag.timeParams).epoch
         if res > wallEpoch + 1:
           return RestApiResponse.jsonError(Http400, InvalidEpochValueError,

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -58,7 +58,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
                                            $epoch.error())
         let
           res = epoch.get()
-          wallTime = node.beaconClock.now() + MAXIMUM_GOSSIP_CLOCK_DISPARITY
+          wallTime = node.beaconClock.now() + node.dag.cfg.gossipClockDisparityDuration
           wallEpoch = wallTime.slotOrZero(node.dag.timeParams).epoch
         if res > wallEpoch + 1:
           return RestApiResponse.jsonError(Http400, InvalidEpochValueError,
@@ -119,7 +119,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
                                            $epoch.error())
         let
           res = epoch.get()
-          wallTime = node.beaconClock.now() + MAXIMUM_GOSSIP_CLOCK_DISPARITY
+          wallTime = node.beaconClock.now() + node.dag.cfg.gossipClockDisparityDuration
           wallEpoch = wallTime.slotOrZero(node.dag.timeParams).epoch
         if res > wallEpoch + 1:
           return RestApiResponse.jsonError(Http400, InvalidEpochValueError,
@@ -402,7 +402,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
                                             $epoch.error())
           let
             res = epoch.get()
-            wallTime = node.beaconClock.now() + MAXIMUM_GOSSIP_CLOCK_DISPARITY
+            wallTime = node.beaconClock.now() + node.dag.cfg.gossipClockDisparityDuration
             wallEpoch = wallTime.slotOrZero(node.dag.timeParams).epoch
           if res > wallEpoch + 1:
             return RestApiResponse.jsonError(Http400, InvalidEpochValueError,
@@ -490,7 +490,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
         if res <= node.dag.finalizedHead.slot:
           return RestApiResponse.jsonError(Http400, InvalidSlotValueError,
                                            "Slot already finalized")
-        let wallTime = node.beaconClock.now() + MAXIMUM_GOSSIP_CLOCK_DISPARITY
+        let wallTime = node.beaconClock.now() + node.dag.cfg.gossipClockDisparityDuration
         if res > wallTime.slotOrZero(node.dag.timeParams):
           return RestApiResponse.jsonError(Http400, InvalidSlotValueError,
                                            "Slot cannot be in the future")
@@ -658,11 +658,11 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
                                            "Slot already finalized")
         let
           wallTime = node.beaconClock.now()
-          maxTime = wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY
+          maxTime = wallTime + node.dag.cfg.gossipClockDisparityDuration
         if qslot > maxTime.slotOrZero(node.dag.timeParams):
           return RestApiResponse.jsonError(
             Http400, InvalidSlotValueError, "Slot cannot be in the future")
-        if qslot + SLOTS_PER_EPOCH < (wallTime - MAXIMUM_GOSSIP_CLOCK_DISPARITY)
+        if qslot + SLOTS_PER_EPOCH < (wallTime - node.dag.cfg.gossipClockDisparityDuration)
             .slotOrZero(node.dag.timeParams):
           return RestApiResponse.jsonError(
             Http400, InvalidSlotValueError,

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -215,8 +215,6 @@ type
   PresetIncompatibleError* = object of CatchableError
 
 func gossipClockDisparityDuration*(cfg: RuntimeConfig): Duration {.inline.} =
-  doAssert cfg.MAXIMUM_GOSSIP_CLOCK_DISPARITY <=
-    Duration.high.milliseconds.uint64
   milliseconds(cfg.MAXIMUM_GOSSIP_CLOCK_DISPARITY.int64)
 
 const
@@ -1292,9 +1290,6 @@ proc readRuntimeConfig*(
     CONFIRMATION_BYZANTINE_THRESHOLD_RANGE, `in`)
 
   # Networking
-  checkParsedValue(
-    "MAX_REQUEST_BLOCKS", cfg.MAX_REQUEST_BLOCKS,
-    1'u64 .. MAX_REQUEST_BLOCKS, `in`)
   checkParsedValue(
     "EPOCHS_PER_SUBNET_SUBSCRIPTION",
     cfg.EPOCHS_PER_SUBNET_SUBSCRIPTION,

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -158,14 +158,14 @@ type
 
     # Networking
     # TODO MAX_PAYLOAD_SIZE*: uint64
-    # TODO MAX_REQUEST_BLOCKS*: uint64
-    # TODO EPOCHS_PER_SUBNET_SUBSCRIPTION*: uint64
+    MAX_REQUEST_BLOCKS*: uint64
+    EPOCHS_PER_SUBNET_SUBSCRIPTION*: uint64
     MIN_EPOCHS_FOR_BLOCK_REQUESTS*: uint64
     # TODO ATTESTATION_PROPAGATION_SLOT_RANGE*: uint64
-    # TODO MAXIMUM_GOSSIP_CLOCK_DISPARITY*: uint64
+    MAXIMUM_GOSSIP_CLOCK_DISPARITY*: uint64
     # TODO MESSAGE_DOMAIN_INVALID_SNAPPY*: array[4, byte]
     # TODO MESSAGE_DOMAIN_VALID_SNAPPY*: array[4, byte]
-    # TODO SUBNETS_PER_NODE*: uint64
+    SUBNETS_PER_NODE*: uint64
     # TODO ATTESTATION_SUBNET_COUNT*: uint64
     # TODO ATTESTATION_SUBNET_EXTRA_BITS*: uint64
     # TODO ATTESTATION_SUBNET_PREFIX_BITS*: uint64
@@ -213,6 +213,11 @@ type
 
   PresetFileError* = object of CatchableError
   PresetIncompatibleError* = object of CatchableError
+
+func gossipClockDisparityDuration*(cfg: RuntimeConfig): Duration {.inline.} =
+  doAssert cfg.MAXIMUM_GOSSIP_CLOCK_DISPARITY <=
+    Duration.high.milliseconds.uint64
+  milliseconds(cfg.MAXIMUM_GOSSIP_CLOCK_DISPARITY.int64)
 
 const
   const_preset* {.strdefine.} = "mainnet"
@@ -379,18 +384,18 @@ when const_preset == "mainnet":
     # `10 * 2**20` (= 10485760, 10 MiB)
     # TODO MAX_PAYLOAD_SIZE: 10485760,
     # `2**10` (= 1024)
-    # TODO MAX_REQUEST_BLOCKS: 1024,
+    MAX_REQUEST_BLOCKS: 1024,
     # `2**8` (= 256)
-    # TODO EPOCHS_PER_SUBNET_SUBSCRIPTION: 256,
+    EPOCHS_PER_SUBNET_SUBSCRIPTION: 256,
     # `MIN_VALIDATOR_WITHDRAWABILITY_DELAY + CHURN_LIMIT_QUOTIENT // 2` (= 33024, ~5 months)
     MIN_EPOCHS_FOR_BLOCK_REQUESTS: 33024,
     # TODO ATTESTATION_PROPAGATION_SLOT_RANGE: 32,
     # 500ms
-    # TODO MAXIMUM_GOSSIP_CLOCK_DISPARITY: 500,
+    MAXIMUM_GOSSIP_CLOCK_DISPARITY: 500,
     # TODO MESSAGE_DOMAIN_INVALID_SNAPPY: [byte 0x00, 0x00, 0x00, 0x00],
     # TODO MESSAGE_DOMAIN_VALID_SNAPPY: [byte 0x01, 0x00, 0x00, 0x00],
     # 2 subnets per node
-    # TODO SUBNETS_PER_NODE: 2,
+    SUBNETS_PER_NODE: 2,
     # 2**8 (= 64)
     # TODO ATTESTATION_SUBNET_COUNT: 64,
     # TODO ATTESTATION_SUBNET_EXTRA_BITS: 0,
@@ -599,18 +604,18 @@ elif const_preset == "gnosis":
     # `10 * 2**20` (= 10485760, 10 MiB)
     # TODO MAX_PAYLOAD_SIZE: 10485760,
     # `2**10` (= 1024)
-    # TODO MAX_REQUEST_BLOCKS: 1024,
+    MAX_REQUEST_BLOCKS: 1024,
     # `2**8` (= 256)
-    # TODO EPOCHS_PER_SUBNET_SUBSCRIPTION: 256,
+    EPOCHS_PER_SUBNET_SUBSCRIPTION: 256,
     # `MIN_VALIDATOR_WITHDRAWABILITY_DELAY + CHURN_LIMIT_QUOTIENT // 2` (= 33024, ~5 months)
     MIN_EPOCHS_FOR_BLOCK_REQUESTS: 33024,
     # TODO ATTESTATION_PROPAGATION_SLOT_RANGE: 32,
     # 500ms
-    # TODO MAXIMUM_GOSSIP_CLOCK_DISPARITY: 500,
+    MAXIMUM_GOSSIP_CLOCK_DISPARITY: 500,
     # TODO MESSAGE_DOMAIN_INVALID_SNAPPY: [byte 0x00, 0x00, 0x00, 0x00],
     # TODO MESSAGE_DOMAIN_VALID_SNAPPY: [byte 0x01, 0x00, 0x00, 0x00],
     # 2 subnets per node
-    # TODO SUBNETS_PER_NODE: 2,
+    SUBNETS_PER_NODE: 2,
     # 2**8 (= 64)
     # TODO ATTESTATION_SUBNET_COUNT: 64,
     # TODO ATTESTATION_SUBNET_EXTRA_BITS: 0,
@@ -814,18 +819,18 @@ elif const_preset == "minimal":
     # `10 * 2**20` (= 10485760, 10 MiB)
     # TODO MAX_PAYLOAD_SIZE: 10485760,
     # `2**10` (= 1024)
-    # TODO MAX_REQUEST_BLOCKS: 1024,
+    MAX_REQUEST_BLOCKS: 1024,
     # `2**8` (= 256)
-    # TODO EPOCHS_PER_SUBNET_SUBSCRIPTION: 256,
+    EPOCHS_PER_SUBNET_SUBSCRIPTION: 256,
     # [customized] `MIN_VALIDATOR_WITHDRAWABILITY_DELAY + CHURN_LIMIT_QUOTIENT // 2` (= 272)
     MIN_EPOCHS_FOR_BLOCK_REQUESTS: 272,
     # TODO ATTESTATION_PROPAGATION_SLOT_RANGE: 32,
     # 500ms
-    # TODO MAXIMUM_GOSSIP_CLOCK_DISPARITY: 500,
+    MAXIMUM_GOSSIP_CLOCK_DISPARITY: 500,
     # TODO MESSAGE_DOMAIN_INVALID_SNAPPY: [byte 0x00, 0x00, 0x00, 0x00],
     # TODO MESSAGE_DOMAIN_VALID_SNAPPY: [byte 0x01, 0x00, 0x00, 0x00],
     # 2 subnets per node
-    # TODO SUBNETS_PER_NODE: 2,
+    SUBNETS_PER_NODE: 2,
     # 2**8 (= 64)
     # TODO ATTESTATION_SUBNET_COUNT: 64,
     # TODO ATTESTATION_SUBNET_EXTRA_BITS: 0,
@@ -937,7 +942,7 @@ template parse(T: type Eth1Address, input: string): T =
   Eth1Address.fromHex(input)
 
 template parse(T: type Hash32, input: string): T =
-  Hash32.fromHex(input)
+  Hash32.fromHex(input.strip(chars = {'"', '\''}))
 
 template parse(T: type UInt256, input: string): T =
   parse(input, UInt256, 10)
@@ -1136,14 +1141,9 @@ proc readRuntimeConfig*(
   checkCompatibility MAX_PAYLOAD_SIZE
   checkCompatibility MAX_PAYLOAD_SIZE, "GOSSIP_MAX_SIZE"
   checkCompatibility MAX_PAYLOAD_SIZE, "MAX_CHUNK_SIZE"
-  checkCompatibility MAX_REQUEST_BLOCKS
-  checkCompatibility EPOCHS_PER_SUBNET_SUBSCRIPTION
   checkCompatibility ATTESTATION_PROPAGATION_SLOT_RANGE
-  checkCompatibility MAXIMUM_GOSSIP_CLOCK_DISPARITY.milliseconds.uint64,
-                     "MAXIMUM_GOSSIP_CLOCK_DISPARITY"
   checkCompatibility MESSAGE_DOMAIN_INVALID_SNAPPY
   checkCompatibility MESSAGE_DOMAIN_VALID_SNAPPY
-  checkCompatibility SUBNETS_PER_NODE
   checkCompatibility ATTESTATION_SUBNET_COUNT
   checkCompatibility ATTESTATION_SUBNET_EXTRA_BITS
   checkCompatibility ATTESTATION_SUBNET_PREFIX_BITS
@@ -1290,6 +1290,22 @@ proc readRuntimeConfig*(
   checkParsedValue(
     "CONFIRMATION_BYZANTINE_THRESHOLD", cfg.CONFIRMATION_BYZANTINE_THRESHOLD,
     CONFIRMATION_BYZANTINE_THRESHOLD_RANGE, `in`)
+
+  # Networking
+  checkParsedValue(
+    "MAX_REQUEST_BLOCKS", cfg.MAX_REQUEST_BLOCKS,
+    1'u64 .. MAX_REQUEST_BLOCKS, `in`)
+  checkParsedValue(
+    "EPOCHS_PER_SUBNET_SUBSCRIPTION",
+    cfg.EPOCHS_PER_SUBNET_SUBSCRIPTION,
+    1'u64 .. uint64.high, `in`)
+  checkParsedValue(
+    "MAXIMUM_GOSSIP_CLOCK_DISPARITY",
+    cfg.MAXIMUM_GOSSIP_CLOCK_DISPARITY,
+    0'u64 .. Duration.high.milliseconds.uint64, `in`)
+  checkParsedValue(
+    "SUBNETS_PER_NODE", cfg.SUBNETS_PER_NODE,
+    1'u64 .. ATTESTATION_SUBNET_COUNT, `in`)
 
   var unknowns: seq[string]
   for name in values.keys:

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -222,6 +222,7 @@ const
 
   # No-longer used values from legacy config files, or quirks of BPO parsing
   ignoredValues = [
+    "TERMINAL_BLOCK_HASH",  # legacy transition value; no longer consumed
     "TTFB_TIMEOUT",  # https://github.com/ethereum/consensus-specs/pull/4532
     "RESP_TIMEOUT",  # https://github.com/ethereum/consensus-specs/pull/4532
     "    MAX_BLOBS_PER_BLOCK",         # parsed separately
@@ -940,7 +941,7 @@ template parse(T: type Eth1Address, input: string): T =
   Eth1Address.fromHex(input)
 
 template parse(T: type Hash32, input: string): T =
-  Hash32.fromHex(input.strip(chars = {'"', '\''}))
+  Hash32.fromHex(input)
 
 template parse(T: type UInt256, input: string): T =
   parse(input, UInt256, 10)

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -776,8 +776,6 @@ func compute_subscribed_subnet(
     doAssert sizeof(UInt256) * 8 == NODE_ID_BITS
     doAssert ATTESTATION_SUBNET_PREFIX_BITS < sizeof(SubnetId) * 8
 
-  doAssert epochsPerSubnetSubscription > 0
-
   let
     node_id_prefix = truncate(
       node_id shr (
@@ -798,10 +796,6 @@ iterator compute_subscribed_subnets*(
     node_id: UInt256, epoch: Epoch,
     epochsPerSubnetSubscription: uint64 = EPOCHS_PER_SUBNET_SUBSCRIPTION,
     subnetsPerNode: uint64 = SUBNETS_PER_NODE): SubnetId =
-  doAssert epochsPerSubnetSubscription > 0
-  doAssert subnetsPerNode > 0
-  doAssert subnetsPerNode <= ATTESTATION_SUBNET_COUNT
-
   for index in 0'u64 ..< subnetsPerNode:
     yield compute_subscribed_subnet(
       node_id, epoch, index, epochsPerSubnetSubscription)

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -770,7 +770,7 @@ func payloadFailSafeInEffect*(
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.4/specs/phase0/p2p-interface.md#attestation-subnet-subscription
 func compute_subscribed_subnet(
     node_id: UInt256, epoch: Epoch, index: uint64,
-    epochsPerSubnetSubscription: uint64): SubnetId =
+    epochsPerSubnetSubscription: UInt256): SubnetId =
   # Ensure neither `truncate` loses information
   static:
     doAssert sizeof(UInt256) * 8 == NODE_ID_BITS
@@ -780,10 +780,11 @@ func compute_subscribed_subnet(
     node_id_prefix = truncate(
       node_id shr (
         NODE_ID_BITS - static(ATTESTATION_SUBNET_PREFIX_BITS.int)), uint64)
-    node_offset = truncate(
-      node_id mod epochsPerSubnetSubscription.u256, uint64)
+    node_offset = node_id mod epochsPerSubnetSubscription
     permutation_seed = eth2digest(uint_to_bytes(
-      uint64((epoch + node_offset) div epochsPerSubnetSubscription)))
+      truncate(
+        (uint64(epoch).u256 + node_offset) div epochsPerSubnetSubscription,
+        uint64)))
     permutated_prefix = compute_shuffled_index(
       node_id_prefix,
       1 shl ATTESTATION_SUBNET_PREFIX_BITS,
@@ -794,8 +795,8 @@ func compute_subscribed_subnet(
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.10/specs/phase0/p2p-interface.md#attestation-subnet-subscription
 iterator compute_subscribed_subnets*(
     node_id: UInt256, epoch: Epoch,
-    epochsPerSubnetSubscription: uint64 = EPOCHS_PER_SUBNET_SUBSCRIPTION,
-    subnetsPerNode: uint64 = SUBNETS_PER_NODE): SubnetId =
+    epochsPerSubnetSubscription: UInt256,
+    subnetsPerNode: uint64): SubnetId =
   for index in 0'u64 ..< subnetsPerNode:
     yield compute_subscribed_subnet(
       node_id, epoch, index, epochsPerSubnetSubscription)

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -768,22 +768,24 @@ func payloadFailSafeInEffect*(
   false
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.4/specs/phase0/p2p-interface.md#attestation-subnet-subscription
-func compute_subscribed_subnet(node_id: UInt256, epoch: Epoch, index: uint64):
-    SubnetId =
+func compute_subscribed_subnet(
+    node_id: UInt256, epoch: Epoch, index: uint64,
+    epochsPerSubnetSubscription: uint64): SubnetId =
   # Ensure neither `truncate` loses information
   static:
-    doAssert EPOCHS_PER_SUBNET_SUBSCRIPTION <= high(uint64)
     doAssert sizeof(UInt256) * 8 == NODE_ID_BITS
     doAssert ATTESTATION_SUBNET_PREFIX_BITS < sizeof(SubnetId) * 8
+
+  doAssert epochsPerSubnetSubscription > 0
 
   let
     node_id_prefix = truncate(
       node_id shr (
         NODE_ID_BITS - static(ATTESTATION_SUBNET_PREFIX_BITS.int)), uint64)
     node_offset = truncate(
-      node_id mod static(EPOCHS_PER_SUBNET_SUBSCRIPTION.u256), uint64)
+      node_id mod epochsPerSubnetSubscription.u256, uint64)
     permutation_seed = eth2digest(uint_to_bytes(
-      uint64((epoch + node_offset) div EPOCHS_PER_SUBNET_SUBSCRIPTION)))
+      uint64((epoch + node_offset) div epochsPerSubnetSubscription)))
     permutated_prefix = compute_shuffled_index(
       node_id_prefix,
       1 shl ATTESTATION_SUBNET_PREFIX_BITS,
@@ -792,9 +794,17 @@ func compute_subscribed_subnet(node_id: UInt256, epoch: Epoch, index: uint64):
   SubnetId((permutated_prefix + index) mod ATTESTATION_SUBNET_COUNT)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.10/specs/phase0/p2p-interface.md#attestation-subnet-subscription
-iterator compute_subscribed_subnets*(node_id: UInt256, epoch: Epoch): SubnetId =
-  for index in 0'u64 ..< SUBNETS_PER_NODE:
-    yield compute_subscribed_subnet(node_id, epoch, index)
+iterator compute_subscribed_subnets*(
+    node_id: UInt256, epoch: Epoch,
+    epochsPerSubnetSubscription: uint64 = EPOCHS_PER_SUBNET_SUBSCRIPTION,
+    subnetsPerNode: uint64 = SUBNETS_PER_NODE): SubnetId =
+  doAssert epochsPerSubnetSubscription > 0
+  doAssert subnetsPerNode > 0
+  doAssert subnetsPerNode <= ATTESTATION_SUBNET_COUNT
+
+  for index in 0'u64 ..< subnetsPerNode:
+    yield compute_subscribed_subnet(
+      node_id, epoch, index, epochsPerSubnetSubscription)
 
 iterator get_committee_indices*(bits: AttestationCommitteeBits): CommitteeIndex =
   for index, b in bits:

--- a/beacon_chain/validators/action_tracker.nim
+++ b/beacon_chain/validators/action_tracker.nim
@@ -47,6 +47,9 @@ type
 
     subscribeAllAttnets: bool
 
+    epochsPerSubnetSubscription: uint64
+    subnetsPerNode: uint64
+
     currentSlot: Slot
       ## Duties that we accept are limited to a range around the current slot
 
@@ -170,7 +173,10 @@ func stabilitySubnets*(tracker: ActionTracker, slot: Slot): AttnetBits =
     allSubnetBits
   else:
     var res: AttnetBits
-    for subnetId in compute_subscribed_subnets(tracker.nodeId, slot.epoch):
+    for subnetId in compute_subscribed_subnets(
+        tracker.nodeId, slot.epoch,
+        tracker.epochsPerSubnetSubscription,
+        tracker.subnetsPerNode):
       res[subnetId.int] = true
     res
 
@@ -297,8 +303,18 @@ func updateActions*(
           (1'u32 shl (duty.slot mod SLOTS_PER_EPOCH))
 
 func init*(
-    T: type ActionTracker, nodeId: UInt256, subscribeAllAttnets: bool): T =
+    T: type ActionTracker,
+    nodeId: UInt256,
+    subscribeAllAttnets: bool,
+    epochsPerSubnetSubscription: uint64 = EPOCHS_PER_SUBNET_SUBSCRIPTION,
+    subnetsPerNode: uint64 = SUBNETS_PER_NODE): T =
+  doAssert epochsPerSubnetSubscription > 0
+  doAssert subnetsPerNode > 0
+  doAssert subnetsPerNode <= ATTESTATION_SUBNET_COUNT
+
   T(
     nodeId: nodeId,
     subscribeAllAttnets: subscribeAllAttnets,
+    epochsPerSubnetSubscription: epochsPerSubnetSubscription,
+    subnetsPerNode: subnetsPerNode,
   )

--- a/beacon_chain/validators/action_tracker.nim
+++ b/beacon_chain/validators/action_tracker.nim
@@ -47,7 +47,7 @@ type
 
     subscribeAllAttnets: bool
 
-    epochsPerSubnetSubscription: uint64
+    epochsPerSubnetSubscription: UInt256
     subnetsPerNode: uint64
 
     currentSlot: Slot
@@ -306,8 +306,8 @@ func init*(
     T: type ActionTracker,
     nodeId: UInt256,
     subscribeAllAttnets: bool,
-    epochsPerSubnetSubscription: uint64 = EPOCHS_PER_SUBNET_SUBSCRIPTION,
-    subnetsPerNode: uint64 = SUBNETS_PER_NODE): T =
+    epochsPerSubnetSubscription: uint64,
+    subnetsPerNode: uint64): T =
   doAssert epochsPerSubnetSubscription > 0
   doAssert subnetsPerNode > 0
   doAssert subnetsPerNode <= ATTESTATION_SUBNET_COUNT
@@ -315,6 +315,6 @@ func init*(
   T(
     nodeId: nodeId,
     subscribeAllAttnets: subscribeAllAttnets,
-    epochsPerSubnetSubscription: epochsPerSubnetSubscription,
+    epochsPerSubnetSubscription: epochsPerSubnetSubscription.u256,
     subnetsPerNode: subnetsPerNode,
   )

--- a/tests/test_action_tracker.nim
+++ b/tests/test_action_tracker.nim
@@ -73,18 +73,17 @@ suite "subnet tracker":
         epochsPerSubnetSubscription = 256,
         subnetsPerNode = 1)
 
+    let
+      subnets64 = tracker64.stabilitySubnets(Epoch(64).start_slot())
+      subnets256 = tracker256.stabilitySubnets(Epoch(64).start_slot())
+
     check:
-      tracker64.stabilitySubnets(Slot(0)).countOnes() == 1
-      tracker256.stabilitySubnets(Slot(0)).countOnes() == 1
-
-    var selectionDiffers = false
-    for e in 0'u64 .. 512'u64:
-      if tracker64.stabilitySubnets(Epoch(e).start_slot()) !=
-          tracker256.stabilitySubnets(Epoch(e).start_slot()):
-        selectionDiffers = true
-        break
-
-    check selectionDiffers
+      subnets64.countOnes() == 1
+      subnets256.countOnes() == 1
+      subnets64[16]
+      not subnets64[49]
+      subnets256[49]
+      not subnets256[16]
 
   test "should register sync committee duties":
     var tracker = ActionTracker.init(

--- a/tests/test_action_tracker.nim
+++ b/tests/test_action_tracker.nim
@@ -17,7 +17,10 @@ from ../beacon_chain/consensus_object_pools/block_pools_types import
 
 suite "subnet tracker":
   test "should register stability subnets on attester duties":
-    var tracker = ActionTracker.init(default(UInt256), false)
+    var tracker = ActionTracker.init(
+        default(UInt256), false,
+        EPOCHS_PER_SUBNET_SUBSCRIPTION,
+        SUBNETS_PER_NODE)
 
     check:
       tracker.stabilitySubnets(Slot(0)).countOnes() == 2
@@ -84,7 +87,10 @@ suite "subnet tracker":
     check selectionDiffers
 
   test "should register sync committee duties":
-    var tracker = ActionTracker.init(default(UInt256), false)
+    var tracker = ActionTracker.init(
+        default(UInt256), false,
+        EPOCHS_PER_SUBNET_SUBSCRIPTION,
+        SUBNETS_PER_NODE)
     let
       pk0 = ValidatorPubKey.fromHex("0xb4102a1f6c80e5c596a974ebd930c9f809c3587dc4d1d3634b77ff66db71e376dbc86c3252c6d140ce031f4ec6167798").get()
       pk1 = ValidatorPubKey.fromHex("0xa00d2954717425ce047e0928e5f4ec7c0e3bbe1058db511303fd659770ddace686ee2e22ac180422e516f4c503eb2228").get()
@@ -120,14 +126,20 @@ suite "subnet tracker":
       not tracker.hasSyncDuty(pk0, Epoch(1024))
 
   test "should subscribe to all subnets when flag is enabled":
-    let tracker = ActionTracker.init(default(UInt256), subscribeAllAttnets = true)
+    let tracker = ActionTracker.init(
+      default(UInt256), true,
+      EPOCHS_PER_SUBNET_SUBSCRIPTION,
+      SUBNETS_PER_NODE)
 
     check:
       tracker.stabilitySubnets(Slot(0)).countOnes() == 64  # All 64 subnets
       tracker.aggregateSubnets(Slot(0)).countOnes() == 0
 
   test "should register and prune PTC duties":
-    var tracker = ActionTracker.init(default(UInt256), false)
+    var tracker = ActionTracker.init(
+        default(UInt256), false,
+        EPOCHS_PER_SUBNET_SUBSCRIPTION,
+        SUBNETS_PER_NODE)
     tracker.updateSlot(Slot(100))
 
     check:
@@ -163,7 +175,10 @@ suite "subnet tracker":
 
   test "should track PTC duties in slot bitmaps":
     var
-      tracker = ActionTracker.init(default(UInt256), false)
+      tracker = ActionTracker.init(
+        default(UInt256), false,
+        EPOCHS_PER_SUBNET_SUBSCRIPTION,
+        SUBNETS_PER_NODE)
       beaconProposers: array[SLOTS_PER_EPOCH, Opt[ValidatorIndex]]
     let shufflingRef = ShufflingRef(
       epoch: Epoch(1),

--- a/tests/test_action_tracker.nim
+++ b/tests/test_action_tracker.nim
@@ -59,6 +59,30 @@ suite "subnet tracker":
       tracker.stabilitySubnets(Slot(0)).countOnes() == 2
       tracker.aggregateSubnets(Slot(0)).countOnes() == 0
 
+  test "should use runtime stability subnet parameters":
+    let
+      tracker64 = ActionTracker.init(
+        default(UInt256), false,
+        epochsPerSubnetSubscription = 64,
+        subnetsPerNode = 1)
+      tracker256 = ActionTracker.init(
+        default(UInt256), false,
+        epochsPerSubnetSubscription = 256,
+        subnetsPerNode = 1)
+
+    check:
+      tracker64.stabilitySubnets(Slot(0)).countOnes() == 1
+      tracker256.stabilitySubnets(Slot(0)).countOnes() == 1
+
+    var selectionDiffers = false
+    for e in 0'u64 .. 512'u64:
+      if tracker64.stabilitySubnets(Epoch(e).start_slot()) !=
+          tracker256.stabilitySubnets(Epoch(e).start_slot()):
+        selectionDiffers = true
+        break
+
+    check selectionDiffers
+
   test "should register sync committee duties":
     var tracker = ActionTracker.init(default(UInt256), false)
     let

--- a/tests/test_conf.nim
+++ b/tests/test_conf.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -10,7 +10,9 @@
 
 import
   unittest2,
-  ../beacon_chain/conf
+  chronos,
+  ../beacon_chain/conf,
+  ../beacon_chain/spec/presets
 
 template reject(val: string) =
   expect CatchableError:
@@ -68,3 +70,100 @@ suite "Configuration parsing":
 
     test "negative epoch":
       reject "3c1e98bf132530c669723f58aa3d395be0d0bfaa653152eecb04605e203bfeb500:-1000"
+
+
+suite "Runtime network configuration":
+  test "defaults preserve compiled networking values":
+    let (cfg, unknowns) = readRuntimeConfig(
+      "PRESET_BASE: " & const_preset & "\n",
+      "runtime-config-defaults")
+
+    check:
+      unknowns.len == 0
+      cfg.MAX_REQUEST_BLOCKS == MAX_REQUEST_BLOCKS
+      cfg.EPOCHS_PER_SUBNET_SUBSCRIPTION ==
+        EPOCHS_PER_SUBNET_SUBSCRIPTION
+      cfg.SUBNETS_PER_NODE == SUBNETS_PER_NODE
+      cfg.gossipClockDisparityDuration ==
+        MAXIMUM_GOSSIP_CLOCK_DISPARITY
+
+  test "custom networking values and quoted Hash32 parse":
+    const nonZeroHash =
+      "0x000102030405060708090a0b0c0d0e0f" &
+      "101112131415161718191a1b1c1d1e1f"
+
+    let
+      base = "PRESET_BASE: " & const_preset & "\n"
+
+      (plainCfg, plainUnknowns) = readRuntimeConfig(
+        base &
+        "TERMINAL_BLOCK_HASH: " & nonZeroHash & "\n",
+        "runtime-config-unquoted-hash")
+
+      (cfg, unknowns) = readRuntimeConfig(
+        base &
+        "TERMINAL_BLOCK_HASH: \"" & nonZeroHash & "\"\n" &
+        "MAX_REQUEST_BLOCKS: 256\n" &
+        "EPOCHS_PER_SUBNET_SUBSCRIPTION: 64\n" &
+        "MAXIMUM_GOSSIP_CLOCK_DISPARITY: 1000\n" &
+        "SUBNETS_PER_NODE: 1\n",
+        "runtime-config-custom")
+
+      (singleQuotedCfg, singleQuoteUnknowns) = readRuntimeConfig(
+        base &
+        "TERMINAL_BLOCK_HASH: '" & nonZeroHash & "'\n",
+        "runtime-config-single-quoted-hash")
+
+    check:
+      plainUnknowns.len == 0
+      unknowns.len == 0
+      singleQuoteUnknowns.len == 0
+
+      plainCfg.TERMINAL_BLOCK_HASH !=
+        defaultRuntimeConfig.TERMINAL_BLOCK_HASH
+      cfg.TERMINAL_BLOCK_HASH ==
+        plainCfg.TERMINAL_BLOCK_HASH
+      singleQuotedCfg.TERMINAL_BLOCK_HASH ==
+        plainCfg.TERMINAL_BLOCK_HASH
+
+      cfg.MAX_REQUEST_BLOCKS == 256
+      cfg.EPOCHS_PER_SUBNET_SUBSCRIPTION == 64
+      cfg.SUBNETS_PER_NODE == 1
+      cfg.MAXIMUM_GOSSIP_CLOCK_DISPARITY == 1000
+      cfg.gossipClockDisparityDuration == milliseconds(1000)
+
+  test "networking guardrails reject invalid values":
+    let base = "PRESET_BASE: " & const_preset & "\n"
+
+    expect PresetFileError:
+      discard readRuntimeConfig(
+        base & "MAX_REQUEST_BLOCKS: 0\n",
+        "runtime-config-max-request-zero")
+
+    expect PresetFileError:
+      discard readRuntimeConfig(
+        base &
+        "MAX_REQUEST_BLOCKS: " & $(MAX_REQUEST_BLOCKS + 1) & "\n",
+        "runtime-config-max-request-too-large")
+
+    expect PresetFileError:
+      discard readRuntimeConfig(
+        base & "EPOCHS_PER_SUBNET_SUBSCRIPTION: 0\n",
+        "runtime-config-epochs-zero")
+
+    expect PresetFileError:
+      discard readRuntimeConfig(
+        base & "SUBNETS_PER_NODE: 0\n",
+        "runtime-config-subnets-zero")
+
+    expect PresetFileError:
+      discard readRuntimeConfig(
+        base &
+        "SUBNETS_PER_NODE: " & $(ATTESTATION_SUBNET_COUNT + 1) & "\n",
+        "runtime-config-subnets-too-large")
+
+    expect PresetFileError:
+      discard readRuntimeConfig(
+        base &
+        "MAXIMUM_GOSSIP_CLOCK_DISPARITY: " & $(high(uint64)) & "\n",
+        "runtime-config-gossip-disparity-too-large")

--- a/tests/test_conf.nim
+++ b/tests/test_conf.nim
@@ -71,7 +71,6 @@ suite "Configuration parsing":
     test "negative epoch":
       reject "3c1e98bf132530c669723f58aa3d395be0d0bfaa653152eecb04605e203bfeb500:-1000"
 
-
 suite "Runtime network configuration":
   test "defaults preserve compiled networking values":
     let (cfg, unknowns) = readRuntimeConfig(
@@ -87,45 +86,22 @@ suite "Runtime network configuration":
       cfg.gossipClockDisparityDuration ==
         MAXIMUM_GOSSIP_CLOCK_DISPARITY
 
-  test "custom networking values and quoted Hash32 parse":
-    const nonZeroHash =
-      "0x000102030405060708090a0b0c0d0e0f" &
-      "101112131415161718191a1b1c1d1e1f"
-
+  test "custom networking values":
     let
       base = "PRESET_BASE: " & const_preset & "\n"
-
-      (plainCfg, plainUnknowns) = readRuntimeConfig(
-        base &
-        "TERMINAL_BLOCK_HASH: " & nonZeroHash & "\n",
-        "runtime-config-unquoted-hash")
-
       (cfg, unknowns) = readRuntimeConfig(
         base &
-        "TERMINAL_BLOCK_HASH: \"" & nonZeroHash & "\"\n" &
+        "TERMINAL_BLOCK_HASH: \"ignored legacy value\"\n" &
         "MAX_REQUEST_BLOCKS: 256\n" &
         "EPOCHS_PER_SUBNET_SUBSCRIPTION: 64\n" &
         "MAXIMUM_GOSSIP_CLOCK_DISPARITY: 1000\n" &
         "SUBNETS_PER_NODE: 1\n",
         "runtime-config-custom")
 
-      (singleQuotedCfg, singleQuoteUnknowns) = readRuntimeConfig(
-        base &
-        "TERMINAL_BLOCK_HASH: '" & nonZeroHash & "'\n",
-        "runtime-config-single-quoted-hash")
-
     check:
-      plainUnknowns.len == 0
       unknowns.len == 0
-      singleQuoteUnknowns.len == 0
-
-      plainCfg.TERMINAL_BLOCK_HASH !=
-        defaultRuntimeConfig.TERMINAL_BLOCK_HASH
       cfg.TERMINAL_BLOCK_HASH ==
-        plainCfg.TERMINAL_BLOCK_HASH
-      singleQuotedCfg.TERMINAL_BLOCK_HASH ==
-        plainCfg.TERMINAL_BLOCK_HASH
-
+        defaultRuntimeConfig.TERMINAL_BLOCK_HASH
       cfg.MAX_REQUEST_BLOCKS == 256
       cfg.EPOCHS_PER_SUBNET_SUBSCRIPTION == 64
       cfg.SUBNETS_PER_NODE == 1

--- a/tests/test_conf.nim
+++ b/tests/test_conf.nim
@@ -135,16 +135,20 @@ suite "Runtime network configuration":
   test "networking guardrails reject invalid values":
     let base = "PRESET_BASE: " & const_preset & "\n"
 
-    expect PresetFileError:
-      discard readRuntimeConfig(
+    let
+      (zeroRequestCfg, zeroRequestUnknowns) = readRuntimeConfig(
         base & "MAX_REQUEST_BLOCKS: 0\n",
         "runtime-config-max-request-zero")
-
-    expect PresetFileError:
-      discard readRuntimeConfig(
+      (maxRequestCfg, maxRequestUnknowns) = readRuntimeConfig(
         base &
-        "MAX_REQUEST_BLOCKS: " & $(MAX_REQUEST_BLOCKS + 1) & "\n",
-        "runtime-config-max-request-too-large")
+        "MAX_REQUEST_BLOCKS: " & $(high(uint64)) & "\n",
+        "runtime-config-max-request-max")
+
+    check:
+      zeroRequestUnknowns.len == 0
+      zeroRequestCfg.MAX_REQUEST_BLOCKS == 0
+      maxRequestUnknowns.len == 0
+      maxRequestCfg.MAX_REQUEST_BLOCKS == high(uint64)
 
     expect PresetFileError:
       discard readRuntimeConfig(

--- a/tests/test_honest_validator.nim
+++ b/tests/test_honest_validator.nim
@@ -351,19 +351,40 @@ suite "Honest validator":
 
   test "Stability subnets":
     check:
-      toSeq(compute_subscribed_subnets(default(UInt256), 0.Epoch)) ==
+      toSeq(compute_subscribed_subnets(
+        default(UInt256), 0.Epoch,
+        EPOCHS_PER_SUBNET_SUBSCRIPTION.u256,
+        SUBNETS_PER_NODE)) ==
         @[49.SubnetId, 50.SubnetId]
-      toSeq(compute_subscribed_subnets(default(UInt256), 1.Epoch)) ==
+      toSeq(compute_subscribed_subnets(
+        default(UInt256), 1.Epoch,
+        EPOCHS_PER_SUBNET_SUBSCRIPTION.u256,
+        SUBNETS_PER_NODE)) ==
         @[49.SubnetId, 50.SubnetId]
-      toSeq(compute_subscribed_subnets(default(UInt256), 2.Epoch)) ==
+      toSeq(compute_subscribed_subnets(
+        default(UInt256), 2.Epoch,
+        EPOCHS_PER_SUBNET_SUBSCRIPTION.u256,
+        SUBNETS_PER_NODE)) ==
         @[49.SubnetId, 50.SubnetId]
-      toSeq(compute_subscribed_subnets(default(UInt256), 2.Epoch)) ==
+      toSeq(compute_subscribed_subnets(
+        default(UInt256), 2.Epoch,
+        EPOCHS_PER_SUBNET_SUBSCRIPTION.u256,
+        SUBNETS_PER_NODE)) ==
         @[49.SubnetId, 50.SubnetId]
-      toSeq(compute_subscribed_subnets(default(UInt256), 200.Epoch)) ==
+      toSeq(compute_subscribed_subnets(
+        default(UInt256), 200.Epoch,
+        EPOCHS_PER_SUBNET_SUBSCRIPTION.u256,
+        SUBNETS_PER_NODE)) ==
         @[49.SubnetId, 50.SubnetId]
-      toSeq(compute_subscribed_subnets(default(UInt256), 300.Epoch)) ==
+      toSeq(compute_subscribed_subnets(
+        default(UInt256), 300.Epoch,
+        EPOCHS_PER_SUBNET_SUBSCRIPTION.u256,
+        SUBNETS_PER_NODE)) ==
         @[16.SubnetId, 17.SubnetId]
-      toSeq(compute_subscribed_subnets(default(UInt256), 400.Epoch)) ==
+      toSeq(compute_subscribed_subnets(
+        default(UInt256), 400.Epoch,
+        EPOCHS_PER_SUBNET_SUBSCRIPTION.u256,
+        SUBNETS_PER_NODE)) ==
         @[16.SubnetId, 17.SubnetId]
 
   test "Index shuffling and unshuffling invert":


### PR DESCRIPTION
## Summary

Make a small set of networking parameters available through Nimbus's existing typed `RuntimeConfig` path instead of requiring compile-time overrides:

- `EPOCHS_PER_SUBNET_SUBSCRIPTION`
- `SUBNETS_PER_NODE`
- `MAXIMUM_GOSSIP_CLOCK_DISPARITY`
- `MAX_REQUEST_BLOCKS`

This is a network-agnostic runtime-config alternative to the compile-time `intdefine` approach in #7618, which helped scope the compatibility gap. It does not add custom-network-specific branches, names, chain IDs, or magic values.

`TERMINAL_BLOCK_HASH` is no longer consumed by Nimbus, so it is treated as an ignored legacy config value rather than adding generic `Hash32` parsing behavior for an inert field.

## Design

The change keeps Nimbus's existing boundary between behavioral runtime configuration and structural/type-level limits.

Runtime consumers use direct typed `RuntimeConfig` fields; there is no dynamic registry or string lookup in protocol hot paths, and stock defaults remain unchanged.

In particular, modern Deneb sync continues to use compile-time `MAX_REQUEST_BLOCKS_DENEB`. Runtime `MAX_REQUEST_BLOCKS` is accepted, stored, and exposed through the config API; Nimbus does not consume it for sync.

`MAXIMUM_GOSSIP_CLOCK_DISPARITY` is propagated to the relevant gossip/validation consumers, including the proposer-duties v2 path added in #8963.

Subnet stability behavior uses the configured `EPOCHS_PER_SUBNET_SUBSCRIPTION` and `SUBNETS_PER_NODE` values. These values are explicit at `ActionTracker` initialization; the subscription period is converted once and stored in `UInt256` form for the subnet calculation.

## Tests

Permanent tests cover:

- custom networking values and ignored legacy `TERMINAL_BLOCK_HASH`
- preservation of compiled networking defaults
- runtime networking guardrails for consumed behavioral values, while unused `MAX_REQUEST_BLOCKS` accepts any `uint64`
- runtime stability-subnet parameters

The generated `AllTests-mainnet.md` inventory is updated accordingly.

Review validation after rebasing onto `unstable` at `fb921544be650d846cdccfca22b1a4b128c710fc`:

- focused runtime-config tests passed under mainnet, minimal, and gnosis presets
- action-tracker tests passed
- full `nimbus_beacon_node` build passed with `-d:disableMarchNative -d:disableLTO`

An earlier revision also passed the broad `make test` gate with **14,302 tests, 0 failures, 0 errors**.

Upstream CI remains authoritative for the normal build matrix.
