### PR TITLE
Subscribe head_v2 post-Gloas

### DIFF
--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -1339,8 +1339,8 @@ func decodeString*(t: typedesc[ConsensusFork],
   ConsensusFork.init(toLowerAscii(value)) or
     err("Unsupported or invalid beacon block fork version")
 
-proc decodeString*(t: typedesc[HeadChangeInfoObject],
-                   value: string): Result[HeadChangeInfoObject, string] =
+proc decodeString*[T: HeadChangeInfoObject | HeadV2ChangeInfoObject](
+                   t: typedesc[T], value: string): Result[T, string] =
   try:
     ok(RestJson.decode(value, t))
   except SerializationError as exc:

--- a/beacon_chain/validator_client/block_service.nim
+++ b/beacon_chain/validator_client/block_service.nim
@@ -439,12 +439,22 @@ proc addOrReplaceProposers*(vc: ValidatorClientRef, epoch: Epoch,
     vc.proposers[epoch] = ProposedData.init(epoch, dependentRoot, tasks)
 
 proc pollForEvents(service: BlockServiceRef, node: BeaconNodeServerRef,
-                   response: RestHttpResponseRef) {.
+                   response: RestHttpResponseRef, topic: static EventTopic) {.
      async: (raises: [CancelledError]).} =
+  when topic == EventTopic.HeadV2:
+    const topicString = "head_v2"
+    type HeadChangeInfoObjectType = HeadV2ChangeInfoObject
+  else:
+    static: doAssert topic == EventTopic.Head
+    const topicString = "head"
+    type HeadChangeInfoObjectType = HeadChangeInfoObject
+    template data(head: HeadChangeInfoObject): auto = head
+
   let vc = service.client
 
   logScope:
     node = node
+    event_topic = topicString
 
   while true:
     let events =
@@ -463,16 +473,16 @@ proc pollForEvents(service: BlockServiceRef, node: BeaconNodeServerRef,
       case event.name
       of "data":
         let
-          head = HeadChangeInfoObject.decodeString(event.data).valueOr:
+          head = HeadChangeInfoObjectType.decodeString(event.data).valueOr:
             debug "Got invalid head event format", reason = error
             return
           blck = EventBeaconBlockObject(
-            slot: head.slot,
-            block_root: head.block_root,
-            optimistic: head.optimistic)
+            slot: head.data.slot,
+            block_root: head.data.block_root,
+            optimistic: head.data.optimistic)
         vc.registerBlock(blck, node)
       of "event":
-        if event.data != "head":
+        if event.data != topicString:
           debug "Got unexpected event name field", event_name = event.name,
                 event_data = event.data
       else:
@@ -500,10 +510,8 @@ proc runBlockEventMonitor(service: BlockServiceRef,
       block:
         var resp: HttpClientResponseRef
         try:
-          resp = await node.client.subscribeEventStream({EventTopic.Head})
-          if resp.status == 200:
-            Opt.some(resp)
-          else:
+          template logErrorMessage(
+              resp: HttpClientResponseRef, topicString: string) =
             let body = await resp.getBodyBytes()
             await resp.closeWait()
             let
@@ -511,15 +519,37 @@ proc runBlockEventMonitor(service: BlockServiceRef,
                         contentType: resp.contentType, data: body)
               reason = plain.getErrorMessage()
             debug "Unable to obtain events stream", code = resp.status,
-                  reason = reason
-            Opt.none(HttpClientResponseRef)
+                  reason = reason, event_topic = topicString
+
+          let
+            currentSlot = vc.getCurrentSlot().get(Slot(0))
+            afterGloas = vc.isPastGloasFork(currentSlot.epoch())
+          if afterGloas:
+            resp = await node.client.subscribeEventStream({EventTopic.HeadV2})
+            if resp.status == 200:
+              Opt.some((resp: resp, useHeadV2: true))
+            else:
+              logErrorMessage(resp, "head_v2")
+              resp = await node.client.subscribeEventStream({EventTopic.Head})
+              if resp.status == 200:
+                Opt.some((resp: resp, useHeadV2: false))
+              else:
+                logErrorMessage(resp, "head")
+                Opt.none(tuple[resp: HttpClientResponseRef, useHeadV2: bool])
+          else:
+            resp = await node.client.subscribeEventStream({EventTopic.Head})
+            if resp.status == 200:
+              Opt.some((resp: resp, useHeadV2: false))
+            else:
+              logErrorMessage(resp, "head")
+              Opt.none(tuple[resp: HttpClientResponseRef, useHeadV2: bool])
         except HttpError as exc:
           debug "Unable to obtain events stream", reason = $exc.msg
-          Opt.none(HttpClientResponseRef)
+          Opt.none(tuple[resp: HttpClientResponseRef, useHeadV2: bool])
         except RestError as exc:
           if not(isNil(resp)): await resp.closeWait()
           debug "Unable to obtain events stream", reason = $exc.msg
-          Opt.none(HttpClientResponseRef)
+          Opt.none(tuple[resp: HttpClientResponseRef, useHeadV2: bool])
         except CancelledError as exc:
           if not(isNil(resp)): await resp.closeWait()
           debug "Block monitoring loop has been interrupted"
@@ -527,13 +557,17 @@ proc runBlockEventMonitor(service: BlockServiceRef,
 
     if response.isSome():
       debug "Block monitoring connection has been established"
+      let (resp, useHeadV2) = response.get()
       try:
-        await service.pollForEvents(node, response.get())
+        if useHeadV2:
+          await service.pollForEvents(node, resp, EventTopic.HeadV2)
+        else:
+          await service.pollForEvents(node, resp, EventTopic.Head)
       except CancelledError as exc:
         raise exc
       finally:
         debug "Block monitoring connection has been lost"
-        await response.get().closeWait()
+        await resp.closeWait()
 
 proc pollForBlockHeaders(service: BlockServiceRef, node: BeaconNodeServerRef,
                          slot: Slot, waitTime: Duration,

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -1078,41 +1078,36 @@ proc getValidatorForDuties*(vc: ValidatorClientRef,
                             slashingSafe = false): Opt[AttachedValidator] =
   vc.attachedValidators[].getValidatorForDuties(key, slot, slashingSafe)
 
-proc isPastElectraFork*(vc: ValidatorClientRef, epoch: Epoch): bool =
+proc isPastConsensusFork(
+    vc: ValidatorClientRef,
+    consensusFork: static ConsensusFork,
+    epoch: Epoch): bool =
   doAssert(len(vc.forks) > 0)
   doAssert(vc.forkConfig.isSome())
-  let electraVersion =
+
+  let forkVersion =
     try:
-      vc.forkConfig.get()[ConsensusFork.Electra].version
+      vc.forkConfig.get()[consensusFork].version
     except KeyError:
-      raiseAssert "Electra fork should be in forks configuration"
+      raiseAssert $consensusFork & " fork should be in forks configuration"
+
   var res = false
   for item in vc.forks:
     if item.epoch <= epoch:
-      if item.current_version == electraVersion:
+      if item.current_version == forkVersion:
         res = true
     else:
       break
   res
+
+proc isPastGloasFork*(vc: ValidatorClientRef, epoch: Epoch): bool =
+  vc.isPastConsensusFork(ConsensusFork.Gloas, epoch)
+
+proc isPastElectraFork*(vc: ValidatorClientRef, epoch: Epoch): bool =
+  vc.isPastConsensusFork(ConsensusFork.Electra, epoch)
 
 proc isPastAltairFork*(vc: ValidatorClientRef, epoch: Epoch): bool =
-  doAssert(len(vc.forks) > 0)
-  doAssert(vc.forkConfig.isSome())
-
-  let altairVersion =
-    try:
-      vc.forkConfig.get()[ConsensusFork.Altair].version
-    except KeyError:
-      raiseAssert "Altair fork should be in forks configuration"
-
-  var res = false
-  for item in vc.forks:
-    if item.epoch <= epoch:
-      if item.current_version == altairVersion:
-        res = true
-    else:
-      break
-  res
+  vc.isPastConsensusFork(ConsensusFork.Altair, epoch)
 
 proc getForkEpoch*(vc: ValidatorClientRef, fork: ConsensusFork): Opt[Epoch] =
   doAssert(len(vc.forks) > 0)


### PR DESCRIPTION
After Gloas, try to open event streams for "head_v2" instead of "head". When it fails, or always before Gloas, fallback to "head".