### PR TITLE
switch remaining unsafeAddr to addr

### DIFF
--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -34,7 +34,7 @@
 #   https://github.com/nim-lang/Nim/issues/14421
 # * Throughout, we're affected by inefficient `let` borrowing, meaning we
 #   often have to take the address of a sequence item due to the above - look
-#   for `let ... = unsafeAddr sequence[idx]`
+#   for `let ... = addr sequence[idx]`
 # * Throughout, we're affected by the overloading rules that prefer a `var`
 #   overload to a non-var overload - look for `asSeq()` - when the `var`
 #   overload is used, the hash tree cache is cleared, which, aside from being

--- a/tests/test_partial_column_quarantine.nim
+++ b/tests/test_partial_column_quarantine.nim
@@ -5,7 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 {.used.}
 
 # Spec references:
@@ -23,11 +23,11 @@ import
 
 func genDigest(index: int): Eth2Digest =
   let tmp = uint64(index).toBytesLE()
-  copyMem(addr result.data[0], unsafeAddr tmp[0], sizeof(uint64))
+  copyMem(addr result.data[0], addr tmp[0], sizeof(uint64))
 
 func gen[T](index: int): T =
   let tmp = uint64(index).toBytesLE()
-  copyMem(addr result.bytes[0], unsafeAddr tmp[0], sizeof(uint64))
+  copyMem(addr result.bytes[0], addr tmp[0], sizeof(uint64))
 
 # --- Fulu helpers ---
 # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.8/specs/fulu/partial-columns/p2p-interface.md#partialdatacolumnheader

--- a/tests/test_response_utils.nim
+++ b/tests/test_response_utils.nim
@@ -35,7 +35,7 @@ func createDigest(data: int): Eth2Digest =
 func genKzgCommitment(index: int): KzgCommitment =
   var res: KzgCommitment
   let tmp = uint64(index).toBytesLE()
-  copyMem(addr res.bytes[0], unsafeAddr tmp[0], sizeof(uint64))
+  copyMem(addr res.bytes[0], addr tmp[0], sizeof(uint64))
   res
 
 func genGloasKzgCommitments(count: int): gloas.KzgCommitments =


### PR DESCRIPTION
https://nim-lang.org/docs/manual.html#statements-and-expressions-the-unsafeaddr-operator
> The `unsafeAddr` operator is a deprecated alias for the `addr` operator