### PR TITLE
sync: preserve peer availability during status refresh

### DIFF
--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -291,6 +291,18 @@ proc getSyncBlockData[A, B](
 
   ok(SyncBlockData(blocks: blocks.asSeq()))
 
+func shouldDelayPeerStatusUpdate*(
+    statusIsFresh: bool,
+    availablePeers: int
+): bool =
+  ## The worker already owns one peer at this point.
+  ##
+  ## Preserve the existing anti-stampede delay only while another
+  ## sync peer remains available. When this worker owns the final
+  ## available peer, refresh its status immediately instead of
+  ## parking the whole sync peer pool in the throttle delay.
+  statusIsFresh and availablePeers > 0
+
 proc getOrUpdatePeerStatus[A, B](
     man: SyncManager[A, B], index: int, peer: A
 ): Future[Result[Slot, string]] {.async: (raises: [CancelledError]).} =
@@ -326,7 +338,10 @@ proc getOrUpdatePeerStatus[A, B](
 
   # Avoid a stampede of requests, but make them more frequent in case the
   # peer is "close" to the slot range of interest
-  if peerStatusAge < (StatusExpirationTime div 2):
+  if shouldDelayPeerStatusUpdate(
+      peerStatusAge < (StatusExpirationTime div 2),
+      man.pool.lenAvailable
+  ):
     await sleepAsync((StatusExpirationTime div 2) - peerStatusAge)
 
   trace "Updating peer's status information",

--- a/tests/test_sync_manager.nim
+++ b/tests/test_sync_manager.nim
@@ -131,6 +131,14 @@ proc setupVerifier(
   (collector(aq), verifier(aq))
 
 suite "SyncManager test suite":
+
+  test "status update throttle preserves final available peer":
+    check:
+      shouldDelayPeerStatusUpdate(true, 0) == false
+      shouldDelayPeerStatusUpdate(true, 1) == true
+      shouldDelayPeerStatusUpdate(false, 0) == false
+      shouldDelayPeerStatusUpdate(false, 1) == false
+
   for kind in [SyncQueueKind.Forward, SyncQueueKind.Backward]:
     asyncTest "[SyncQueue# & " & $kind & "] Smoke [single peer] test":
       # Four ranges was distributed to single peer only.


### PR DESCRIPTION
## Summary

- avoid the status-refresh throttle when a worker owns the final available sync peer
- preserve the existing anti-stampede delay while another peer remains available
- add regression coverage for fresh/stale status with zero/one remaining available peer

## Problem

`getOrUpdatePeerStatus` runs after a worker has acquired a peer. When the cached status is still fresh, the current code sleeps before refreshing it.

Under low-peer conditions, workers can each retain a peer while sleeping in this throttle. If the final available peer is retained this way, the pool can temporarily have no peer available for other sync workers, preventing forward progress.

## Change

Delay only when both conditions hold:

1. the peer status is still fresh enough for the existing throttle; and
2. at least one other sync peer remains available in the pool.

When the current worker owns the final available peer, refresh its status immediately instead of sleeping while holding that peer.

The existing anti-stampede behavior is otherwise unchanged.

## Tests

Added a regression test covering all four policy cases:

- fresh status, 0 other peers available -> do not delay
- fresh status, 1 other peer available -> delay
- stale status, 0 other peers available -> do not delay
- stale status, 1 other peer available -> do not delay

Validation on the current `unstable` base:

- `tests/test_sync_manager.nim`: 26/26 passed
- the same focused test binary was then run 30 additional times: 30/30 passed
- full `nimbus_beacon_node` build passed

The underlying low-peer behavior was also reproduced separately in a controlled two-peer A/B: the unpatched implementation could retain both peers in status refresh and stop making progress, while the patched implementation recovered and remained live.

This is intentionally a small change to the current sync manager. I am aware that #7921 is reworking the syncing subsystem; if that work replaces this path, the regression scenario should still be useful when checking equivalent peer-retention behavior.
