### PR TITLE
fix(vc): skip produceAttestationData when no attester duties

### DIFF
--- a/beacon_chain/validator_client/attestation_service.nim
+++ b/beacon_chain/validator_client/attestation_service.nim
@@ -534,6 +534,10 @@ proc spawnAttestationTasksV2(
     vc = service.client
     duties = vc.getAttesterDutiesForSlot(slot)
 
+  if len(duties) == 0:
+    debug "No attestation duties scheduled for slot", slot = slot
+    return
+
   # Waiting for blocks to be published before attesting.
   await vc.waitForBlock(slot, vc.timeParams.attestationSlotOffset)
 


### PR DESCRIPTION
## Summary
- Do not call `produceAttestationData` (or wait for attestation-due) when the slot has no attester duties.
- Matches Lodestar, Teku, Lighthouse, and Prysm, and matches the honest-validator spec (attest on the assigned slot only).
- Stops idle-slot BN/middleware timeouts and “Beacon node down” log spam.
Lighthouse hit the same every-slot fetch after an Electra refactor and fixed it in [sigp/lighthouse#8559](https://github.com/sigp/lighthouse/pull/8559) (“Do not request attestation data when attestation duty is empty”).

## Problem
The attestation service runs every slot. With no attester duty it still waited until attestation-due and called `GET /eth/v1/validator/attestation_data`. That is not required by the spec: a validator attests once per epoch on the slot from `get_committee_assignment`, which returns `None` when there is no assignment ([phase0 honest validator — Attesting](https://ethereum.github.io/consensus-specs/specs/phase0/validator/#attesting)).
Against a local BN this is wasted traffic. Against Obol Charon the endpoint **blocks on DutyDB** until the cluster has attestation data for a real duty, so an idle slot never returns. The VC then times out and flaps the node:
Against a local BN this is wasted traffic. Against Obol Charon the endpoint **blocks on DutyDB** until the cluster has attestation data for a real duty, so an idle slot never returns. The VC then times out and marks the beacon node down (it is logged online again shortly after):
```
t+0.000s  INF  Slot start        node_status=synced delay=~2ms
t+7.5s    WRN  Beacon node down  reason="Timeout exceeded … produceAttestationData(best)"
t+7.5s    WRN  Unable to proceed attestations  duties_count=0  service=attestation_service
```
`duties_count=0` means no attester duty *this slot* (`Slot start` also shows `attestationIn` many minutes away).  On a duty slot the same path publishes normally (~50ms after attestation-due).

## Approach
In `spawnAttestationTasksV2`, return immediately when `getAttesterDutiesForSlot` is empty.

## Test plan

- [x] Unit tests in `tests/test_validator_client.nim` for `getAttesterDutiesForSlot`: empty map, duty on another slot, duty on the requested slot
- [x] CI unit suite / `test_validator_client`

## AI assistance disclosure

I used Cursor to help inspect the Nimbus VC attestation loop, compare other clients and the honest-validator spec, draft this patch, and prepare this PR text. I reviewed the resulting diff and can explain the change. A human author remains responsible for the submitted code (see Status/Logos contributor guidance on AI-assisted work: allowed for drafting; the opener must review, verify, and be able to explain every change; PRs should not be opened automatically by an agent/bot). I am a node operator rather than a regular Nimbus contributor; corrections from maintainers are welcome.
