### PR TITLE
Use BN --graffiti if VC doesn't specify one

### DIFF
--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -517,7 +517,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
           res.get()
       qgraffiti =
         if graffiti.isNone():
-          defaultGraffitiBytes()
+          node.config.defaultGraffitiBytes()
         else:
           let res = graffiti.get()
           if res.isErr():


### PR DESCRIPTION
Currently BN returns the static default graffiti if VC doesn't provide one, rather than the user configured --graffiti, leading to #7446. Change the default to the user choice, fixing this for non-Nimbus VC. (Nimbus VC currently always uses the VC graffiti, never the BN default)