### PR TITLE
fix(vc): decode GAS_LIMIT_SCHEDULE arrays in getSpec

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -828,6 +828,7 @@ AllTests-mainnet
 + KzgProof                                                                                   OK
 + RestErrorMessage parser tests                                                              OK
 + RestErrorMessage writer tests                                                              OK
++ VCRuntimeConfig getSpec BLOB_SCHEDULE and GAS_LIMIT_SCHEDULE arrays                        OK
 + Validator pubkey hack                                                                      OK
 + remote signing example AGGREGATE_AND_PROOF (DEPRECATED)                                    OK
 + remote signing example AGGREGATE_AND_PROOF_V2 (ELECTRA)                                    OK

--- a/beacon_chain/spec/eth2_apis/eth2_rest_json_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_json_serialization.nim
@@ -1139,9 +1139,11 @@ proc readValue*(
     r: var RestJsonReader, value: var VCRuntimeConfig
 ) {.raises: [SerializationError, IOError].} =
   for fieldName in readObjectFields(r):
+    # Beacon API getSpec returns array-valued config keys as JSON arrays.
+    # https://ethereum.github.io/beacon-APIs/#/Config/getSpec
     let fieldValue =
       case toLowerAscii(fieldName)
-      of "blob_schedule":
+      of "blob_schedule", "gas_limit_schedule":
         string(r.readValue(JsonString))
       else:
         r.readValue(string)

--- a/tests/test_eth2_rest_serialization.nim
+++ b/tests/test_eth2_rest_serialization.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2025 Status Research & Development GmbH
+# Copyright (c) 2021-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -400,6 +400,57 @@ suite "REST encoding and decoding":
     for vector in InvalidCharsVectors2:
       let res = strictParse(vector, UInt256, 2)
       check res.isErr()
+
+  test "VCRuntimeConfig getSpec BLOB_SCHEDULE and GAS_LIMIT_SCHEDULE arrays":
+    # Beacon API getSpec returns array-valued keys as JSON arrays, not strings.
+    # Lodestar/consensus-spec expose GAS_LIMIT_SCHEDULE the same way as BLOB_SCHEDULE.
+    const emptySpec = """
+      {
+        "SECONDS_PER_SLOT": "12",
+        "BLOB_SCHEDULE": [],
+        "GAS_LIMIT_SCHEDULE": []
+      }
+    """
+    let emptyCfg = RestJson.decode(emptySpec, VCRuntimeConfig)
+    check:
+      emptyCfg["SECONDS_PER_SLOT"] == "12"
+      emptyCfg["BLOB_SCHEDULE"] == "[]"
+      emptyCfg["GAS_LIMIT_SCHEDULE"] == "[]"
+
+    const populatedSpec = """
+      {
+        "SECONDS_PER_SLOT": "12",
+        "BLOB_SCHEDULE": [
+          {"EPOCH": "269568", "MAX_BLOBS_PER_BLOCK": "6"}
+        ],
+        "GAS_LIMIT_SCHEDULE": [
+          {"EPOCH": "500000", "GAS_LIMIT": "60000000"}
+        ]
+      }
+    """
+    let populatedCfg = RestJson.decode(populatedSpec, VCRuntimeConfig)
+    check:
+      populatedCfg["SECONDS_PER_SLOT"] == "12"
+      "269568" in populatedCfg["BLOB_SCHEDULE"]
+      "MAX_BLOBS_PER_BLOCK" in populatedCfg["BLOB_SCHEDULE"]
+      "500000" in populatedCfg["GAS_LIMIT_SCHEDULE"]
+      "GAS_LIMIT" in populatedCfg["GAS_LIMIT_SCHEDULE"]
+      "60000000" in populatedCfg["GAS_LIMIT_SCHEDULE"]
+
+    const wrappedSpec = """
+      {
+        "data": {
+          "SECONDS_PER_SLOT": "12",
+          "GAS_LIMIT_SCHEDULE": [{"EPOCH": "0", "GAS_LIMIT": "60000000"}]
+        }
+      }
+    """
+    let resp = RestJson.decode(wrappedSpec, GetSpecVCResponse)
+    check:
+      resp.data["SECONDS_PER_SLOT"] == "12"
+      "EPOCH" in resp.data["GAS_LIMIT_SCHEDULE"]
+      "GAS_LIMIT" in resp.data["GAS_LIMIT_SCHEDULE"]
+      "60000000" in resp.data["GAS_LIMIT_SCHEDULE"]
 
   let examples = Json.decode(Web3SignerExamples, Table[string, Table[string, JsonString]])
 


### PR DESCRIPTION
## Summary
- Accept `GAS_LIMIT_SCHEDULE` from Beacon API `GET /eth/v1/config/spec` as a JSON array (same path as `BLOB_SCHEDULE`) in VC `VCRuntimeConfig` decoding.
- Stops Nimbus VC from failing getSpec decode when a BN returns `GAS_LIMIT_SCHEDULE: []` or a populated schedule, which was flapping the BN Online/Offline.
- Adds a REST serialization unit test and refreshes `AllTests-mainnet.md` (`all_tests` path) per Nimbus CI expectations.

## Problem
Beacon API `getSpec` returns array-valued config keys as JSON arrays. Nimbus VC only allowlisted `blob_schedule` as non-string, so Lodestar (and any BN) returning `GAS_LIMIT_SCHEDULE` as `[]` or with entries failed decode.

This showed up against Lodestar `v1.47.0`, which always exposed `GAS_LIMIT_SCHEDULE` from getSpec (including empty on mainnet). Related Lodestar change and discussion:

- Lodestar PR: https://github.com/ChainSafe/lodestar/pull/10004 — temporary omit-until-Gloas interop guard on Lodestar’s side
- Review note from nflaig: https://github.com/ChainSafe/lodestar/pull/10004#discussion_r3942033465 — lasting fix belongs on Nimbus (parse/allowlist array-valued `GAS_LIMIT_SCHEDULE` like `BLOB_SCHEDULE`); Lodestar returning an array matches the API / consensus-spec shape

Consensus-spec mainnet config includes `GAS_LIMIT_SCHEDULE: []`; clients that emit the field as a JSON array are correct. The durable interop fix is VC-side decoding.

## Approach
In `beacon_chain/spec/eth2_apis/eth2_rest_json_serialization.nim`, treat `gas_limit_schedule` like `blob_schedule` when reading `VCRuntimeConfig`.

## Test plan
- [x] Unit test in `tests/test_eth2_rest_serialization.nim`: empty and populated `BLOB_SCHEDULE` / `GAS_LIMIT_SCHEDULE`, plus wrapped `GetSpecVCResponse`
- [x] Ran `all_tests` (new test OK); refreshed `AllTests-mainnet.md` with the new REST suite line

## AI assistance disclosure

I used Cursor to help inspect getSpec / `VCRuntimeConfig` decoding, cross-check Lodestar#10004 and the Beacon API array behavior, draft this patch and tests, regenerate `AllTests-mainnet.md`, and prepare this PR text. I reviewed the resulting diff and can explain the change. A human author remains responsible for the submitted code (see Status/Logos contributor guidance on AI-assisted work: allowed for drafting; the opener must review, verify, and be able to explain every change; PRs should not be opened automatically by an agent/bot). I am a node operator rather than a regular Nimbus contributor; corrections from maintainers are welcome.
