### PR TITLE
Support import of pre-Capella state after post-Capella init

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -45,6 +45,7 @@ AllTests-mainnet
 + empty database [Preset: mainnet]                                                           OK
 + find ancestors [Preset: mainnet]                                                           OK
 + head blocks roundtrip [Preset: mainnet]                                                    OK
++ pre-Capella withdrawal credentials [Preset: mainnet]                                       OK
 + sanity check altair and cross-fork getState rollback [Preset: mainnet]                     OK
 + sanity check altair blocks [Preset: mainnet]                                               OK
 + sanity check altair states [Preset: mainnet]                                               OK

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -31,6 +31,7 @@ logScope: topics = "bc_db"
 type
   DbSeq*[T] = object
     insertStmt: SqliteStmt[openArray[byte], void]
+    updateStmt: SqliteStmt[(seq[byte], int64), void]
     selectStmt: SqliteStmt[int64, openArray[byte]]
     recordCount: int64
 
@@ -104,6 +105,7 @@ type
     # queries. (v1.4.0+)
     immutableValidatorsDb*: DbSeq[ImmutableValidatorDataDb2]
     immutableValidators*: seq[ImmutableValidatorData2]
+    firstPostCapellaValidatorIndex: int
 
     checkpoint*: proc() {.gcsafe, raises: [].}
 
@@ -292,6 +294,10 @@ proc init*[T](
         "INSERT INTO '" & name & "'(value) VALUES (?);",
         openArray[byte], void, managed = false).expect("this is a valid statement")
 
+      updateStmt = db.prepareStmt(
+        "UPDATE '" & name & "' SET value = ? WHERE id = ?;",
+        (seq[byte], int64), void, managed = false).expect("this is a valid statement")
+
       selectStmt = db.prepareStmt(
         "SELECT value FROM '" & name & "' WHERE id = ?;",
         int64, openArray[byte], managed = false).expect("this is a valid statement")
@@ -310,6 +316,7 @@ proc init*[T](
     countStmt.dispose()
 
     ok(Seq(insertStmt: insertStmt,
+          updateStmt: updateStmt,
           selectStmt: selectStmt,
           recordCount: recordCount))
   else:
@@ -317,12 +324,14 @@ proc init*[T](
 
 proc close*(s: var DbSeq) =
   s.insertStmt.dispose()
+  s.updateStmt.dispose()
   s.selectStmt.dispose()
 
   reset(s)
 
 proc add*[T](s: var DbSeq[T], val: T) =
-  doAssert(distinctBase(s.insertStmt) != nil, "database closed or table not preset")
+  doAssert(distinctBase(s.insertStmt) != nil,
+    "database closed or table not preset")
   let bytes = SSZ.encode(val)
   s.insertStmt.exec(bytes).expectDb()
   inc s.recordCount
@@ -330,9 +339,16 @@ proc add*[T](s: var DbSeq[T], val: T) =
 template len*[T](s: DbSeq[T]): int64 =
   s.recordCount
 
+proc put*[T](s: var DbSeq[T], idx: int64, val: T) =
+  doAssert(distinctBase(s.updateStmt) != nil,
+    "database closed or table not preset")
+  doAssert(idx < s.len, $T & " not found at index " & $(idx))
+  s.updateStmt.exec((SSZ.encode(val), idx + 1)).expectDb()
+
 proc get*[T](s: DbSeq[T], idx: int64): T =
   # This is used only locally
-  doAssert(distinctBase(s.selectStmt) != nil, $T & " table not present for read at " & $(idx))
+  doAssert(distinctBase(s.selectStmt) != nil,
+    $T & " table not present for read at " & $(idx))
 
   let resultAddr = addr result
 
@@ -988,7 +1004,8 @@ proc delExecutionPayloadEnvelope*(db: BeaconChainDB, root: Eth2Digest): bool =
   db.envelopes.del(root.data).expectDb()
 
 proc updateImmutableValidators*(
-    db: BeaconChainDB, validators: openArray[Validator]) =
+    db: BeaconChainDB, validators: openArray[Validator],
+    afterCapella: static bool) =
   # Must be called before storing a state that references the new validators
   let numValidators = validators.len
 
@@ -1000,6 +1017,20 @@ proc updateImmutableValidators*(
         pubkey: immutableValidator.pubkey.toUncompressed(),
         withdrawal_credentials: immutableValidator.withdrawal_credentials)
     db.immutableValidators.add immutableValidator
+
+  when not afterCapella:
+    # Fix up `withdrawal_credentials` originally imported post-Capella
+    while db.firstPostCapellaValidatorIndex < numValidators:
+      let
+        i = db.firstPostCapellaValidatorIndex
+        credentials = validators[i].withdrawal_credentials
+      if db.immutableValidators[i].withdrawal_credentials != credentials:
+        if not db.db.readOnly:
+          db.immutableValidatorsDb.put(i, ImmutableValidatorDataDb2(
+            pubkey: db.immutableValidators[i].pubkey.toUncompressed(),
+            withdrawal_credentials: credentials))
+        assign(db.immutableValidators[i].withdrawal_credentials, credentials)
+      inc db.firstPostCapellaValidatorIndex
 
 template BeaconStateNoImmutableValidators(kind: static ConsensusFork): auto =
   when kind == ConsensusFork.Heze:
@@ -1029,7 +1060,8 @@ template toBeaconStateNoImmutableValidators(state: ForkyBeaconState): auto =
 proc putState*(db: BeaconChainDB, key: Eth2Digest, value: ForkyBeaconState) =
   const consensusFork = typeof(value).kind
   doAssert db.statesNoVal[consensusFork] != nil
-  db.updateImmutableValidators(value.validators.asSeq())
+  db.updateImmutableValidators(
+    value.validators.asSeq(), consensusFork >= ConsensusFork.Capella)
   when consensusFork >= ConsensusFork.Bellatrix:
     db.statesNoVal[consensusFork].putSZSSZ(
       key.data, toBeaconStateNoImmutableValidators(value))

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -102,7 +102,8 @@ proc addResolvedHeadBlock(
   # Regardless of the chain we're on, the deposits come in the same order so
   # as soon as we import a block, we'll also update the shared public key
   # cache
-  dag.updateValidatorKeys(state.validators)
+  dag.updateValidatorKeys(
+    state.validators, consensusFork >= ConsensusFork.Capella)
 
   # Getting epochRef with the state will potentially create a new EpochRef
   let

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -136,13 +136,15 @@ func get_fork_choice_balances*(
         else:
           distinctBase(validator[].effective_balance))
 
-proc updateValidatorKeys*(dag: ChainDAGRef, validators: openArray[Validator]) =
+proc updateValidatorKeys*(
+    dag: ChainDAGRef, validators: openArray[Validator],
+    afterCapella: static bool) =
   # Update validator key cache - must be called every time a valid block is
   # applied to the state - this is important to ensure that when we sync blocks
   # without storing a state (non-epoch blocks essentially), the deposits from
   # those blocks are persisted to the in-database cache of immutable validator
   # data (but no earlier than that the whole block as been validated)
-  dag.db.updateImmutableValidators(validators)
+  dag.db.updateImmutableValidators(validators, afterCapella)
 
 proc updateFinalizedBlocks*(db: BeaconChainDB, newFinalized: openArray[BlockId]) =
   if db.db.readOnly: return # TODO abstraction leak - where to put this?
@@ -1634,7 +1636,9 @@ proc init*(
 
   # Fill validator key cache in case we're loading an old database that doesn't
   # have a cache
-  dag.updateValidatorKeys(dag.headState.validators)
+  withState(dag.headState):
+    dag.updateValidatorKeys(
+      forkyState.data.validators.asSeq, consensusFork >= ConsensusFork.Capella)
 
   # Initialize pruning such that when starting with a database that hasn't been
   # pruned, we work our way from the tail to the horizon in incremental steps

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -280,6 +280,46 @@ suite "Beacon chain DB" & preset():
       else:
         consensusFork.doStateTestReusingBuffers()
 
+  test "pre-Capella withdrawal credentials" & preset():
+    let db = cfg.makeTestDB(SLOTS_PER_EPOCH)
+
+    # Post-Capella, withdrawal credentials can change.
+    # The first stored state sets the credentials in immutableValidators;
+    # pretend that an earlier version wrote the immutableValidators already
+    block:
+      let i = db.immutableValidators.len div 2
+      var credentials = db.immutableValidators[i].withdrawal_credentials
+      credentials.data[0] = ETH1_ADDRESS_WITHDRAWAL_PREFIX
+      db.immutableValidatorsDb.put(i, ImmutableValidatorDataDb2(
+        pubkey: db.immutableValidators[i].pubkey.toUncompressed(),
+        withdrawal_credentials: credentials))
+
+    let db2 = BeaconChainDB.new(db.db, cfg)
+
+    # New validators get appended to immutableValidators with latest credentials
+    block:
+      let state = assignClone(testStates[ConsensusFork.Capella][0][])
+      template forkyState: untyped = state[].capellaData
+      for i in 0 ..< forkyState.data.validators.len:
+        template val: auto = forkyState.data.validators.mitem(i)
+        val.withdrawal_credentials.data[0] = ETH1_ADDRESS_WITHDRAWAL_PREFIX
+      forkyState.root = hash_tree_root(forkyState.data)
+      db2.putState(forkyState.root, forkyState.data)
+
+    # Storing a pre-Capella state restores pre-Capella withdrawal credentials
+    # (e.g., importing from Era file)
+    let state = testStates[ConsensusFork.Bellatrix][0]
+    template forkyState: untyped = state[].bellatrixData
+    db2.putState(forkyState.root, forkyState.data)
+
+    # Check that restored pre-Capella withdrawal credentials are persisted
+    let
+      db3 = BeaconChainDB.new(db.db, cfg)
+      state2 = db3.getStateRef(ConsensusFork.Bellatrix, forkyState.root)
+    check hash_tree_root(state2[]) == forkyState.root
+
+    db3.close()
+
   template doRollbackTest(consensusFork: static ConsensusFork): untyped =
     block:
       let


### PR DESCRIPTION
Pre-Capella states in don't store their withdrawal credentials in the database and rely on the shared immutableValidators list. Because credentials can change post-Capella, depending on storage order, it may be necessary to fix up any updated credentials with their historical pre-Capella version when storing pre-Capella states.

Closes #7527