### PR TITLE
nix: disable stripping debug symbols

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -51,6 +51,7 @@ in stdenv.mkDerivation rec {
     with pkgs; [ nim which fakeGit ]
     ++ lib.optionals stdenv.isDarwin [ pkgs.darwin.cctools ];
 
+  dontStrip = true;
   enableParallelBuilding = true;
 
   # Disable CPU optimizations that make binary not portable.


### PR DESCRIPTION
Important for debugging at the cost of increasing binary size 4x. From `~23 MB` to `~93 MB` for beacon node.

Result:
```
> readelf -S result/bin/nimbus_beacon_node | grep debug
 [30] .debug_aranges    PROGBITS         0000000000000000  03adb650
 [31] .debug_info       PROGBITS         0000000000000000  03addad0
 [32] .debug_abbrev     PROGBITS         0000000000000000  08d530cf
 [33] .debug_line       PROGBITS         0000000000000000  08e68673
 [34] .debug_str        PROGBITS         0000000000000000  0b4ad98c
 [35] .debug_line_str   PROGBITS         0000000000000000  0bf66089
 [36] .debug_loclists   PROGBITS         0000000000000000  0bf8ab92
 [37] .debug_macro      PROGBITS         0000000000000000  0ee24db2
 [38] .debug_rnglists   PROGBITS         0000000000000000  0f3bec1a
```