### PR TITLE
rm missing envelope request slot filters

### DIFF
--- a/beacon_chain/sync/sync_overseer2.nim
+++ b/beacon_chain/sync/sync_overseer2.nim
@@ -1425,7 +1425,7 @@ proc getMissingEnvelopeBlocksAndRequest(
         overseer.missingRoots.incl(bid.root)
         continue
 
-    if (bid.slot >= dag.head.slot) and (bid.root notin duplicates):
+    if bid.root notin duplicates:
       duplicates.incl(bid.root)
       bres.blocks.add(signedBlock)
       bres.roots.add(bid.root)
@@ -1445,7 +1445,7 @@ proc getMissingEnvelopeBlocksAndRequest(
         continue
       bid = signedBlock.toBlockId()
 
-    if (bid.slot >= dag.head.slot) and (bid.root notin duplicates):
+    if bid.root notin duplicates:
       duplicates.incl(bid.root)
       bres.blocks.add(signedBlock)
       bres.roots.add(bid.root)


### PR DESCRIPTION
Generally speaking, in Gloas, the CL head can move regardless ahead of the envelopes, and in particular the CL head resolves/updates regardless of/before later envelope missing envelope requests